### PR TITLE
fix: prevent theme transition flash

### DIFF
--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 
 type ViewTransition = {
   ready: Promise<void>
+  finished: Promise<void>
 }
 
 type ViewTransitionDocument = {
@@ -9,8 +10,11 @@ type ViewTransitionDocument = {
 }
 
 const themeStorageKey = 'theme'
-const themeRippleDuration = 640
 const isDark = ref(document.documentElement.classList.contains('dark'))
+const themeTransitionClass = 'theme-transitioning'
+const themeRippleXVariable = '--theme-ripple-x'
+const themeRippleYVariable = '--theme-ripple-y'
+const themeRippleRadiusVariable = '--theme-ripple-radius'
 
 function prefersDarkMode(): boolean {
   const savedTheme = localStorage.getItem(themeStorageKey)
@@ -47,28 +51,20 @@ function getRippleRadius(x: number, y: number): number {
   )
 }
 
-function animateThemeRipple(transition: ViewTransition, x: number, y: number) {
-  void transition.ready
-    .then(() => {
-      const endRadius = getRippleRadius(x, y)
-      const options: KeyframeAnimationOptions & { pseudoElement: string } = {
-        duration: themeRippleDuration,
-        easing: 'cubic-bezier(0.65, 0, 0.35, 1)',
-        pseudoElement: '::view-transition-new(root)',
-      }
+function prepareThemeRipple(x: number, y: number) {
+  const root = document.documentElement
+  root.style.setProperty(themeRippleXVariable, `${x}px`)
+  root.style.setProperty(themeRippleYVariable, `${y}px`)
+  root.style.setProperty(themeRippleRadiusVariable, `${getRippleRadius(x, y)}px`)
+  root.classList.add(themeTransitionClass)
+}
 
-      // 用新主题截图做圆形裁剪，让颜色从点击位置像水波一样扩散。
-      document.documentElement.animate(
-        {
-          clipPath: [
-            `circle(0px at ${x}px ${y}px)`,
-            `circle(${endRadius}px at ${x}px ${y}px)`,
-          ],
-        },
-        options
-      )
-    })
-    .catch(() => undefined)
+function cleanupThemeRipple() {
+  const root = document.documentElement
+  root.classList.remove(themeTransitionClass)
+  root.style.removeProperty(themeRippleXVariable)
+  root.style.removeProperty(themeRippleYVariable)
+  root.style.removeProperty(themeRippleRadiusVariable)
 }
 
 export function setTheme(nextIsDark: boolean, event?: MouseEvent) {
@@ -80,14 +76,17 @@ export function setTheme(nextIsDark: boolean, event?: MouseEvent) {
   }
 
   const { clientX, clientY } = event
+  prepareThemeRipple(clientX, clientY)
+
   const viewTransitionDocument = document as unknown as ViewTransitionDocument
   const transition = viewTransitionDocument.startViewTransition?.(() => {
     persistTheme(nextIsDark)
   })
 
   if (transition) {
-    animateThemeRipple(transition, clientX, clientY)
+    void transition.finished.finally(cleanupThemeRipple)
   } else {
+    cleanupThemeRipple()
     persistTheme(nextIsDark)
   }
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -44,10 +44,9 @@
     background-attachment: fixed;
   }
 
-  /* 主题切换使用 View Transition API，关闭默认淡入淡出后交给圆形水波裁剪动画。 */
+  /* 主题切换使用 View Transition API。新主题层首帧即裁剪，避免先全屏闪现再执行水波。 */
   ::view-transition-group(root),
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
+  ::view-transition-old(root) {
     animation: none;
   }
 
@@ -70,6 +69,24 @@
 
   ::view-transition-new(root) {
     z-index: 2147483646;
+    clip-path: circle(0 at var(--theme-ripple-x, 50vw) var(--theme-ripple-y, 50vh));
+    animation: theme-ripple-reveal 640ms cubic-bezier(0.65, 0, 0.35, 1) both;
+  }
+
+  html.theme-transitioning *,
+  html.theme-transitioning *::before,
+  html.theme-transitioning *::after {
+    transition: none !important;
+  }
+
+  @keyframes theme-ripple-reveal {
+    from {
+      clip-path: circle(0 at var(--theme-ripple-x, 50vw) var(--theme-ripple-y, 50vh));
+    }
+
+    to {
+      clip-path: circle(var(--theme-ripple-radius, 150vmax) at var(--theme-ripple-x, 50vw) var(--theme-ripple-y, 50vh));
+    }
   }
 
   /* 自定义滚动条 - 仅针对 Firefox，避免 Chrome 取消 webkit 的全局定制 */


### PR DESCRIPTION
Prevent the page background from flashing during light/dark theme switching.

Changes

- Move the theme ripple animation setup into CSS-owned first-frame state.
- Add a temporary theme-transitioning class during the View Transition API animation.
- Disable normal element transitions while the theme ripple is running to avoid a second color fade underneath the reveal animation.

Verification

- Verified the branch diff only touches:
  - frontend/src/composables/useTheme.ts
  - frontend/src/style.css
