### PR TITLE
修复模型广场生图独立倍率展示

### DIFF
--- a/backend/internal/handler/dto/model_marketplace.go
+++ b/backend/internal/handler/dto/model_marketplace.go
@@ -88,6 +88,8 @@ type ModelMarketplaceGroup struct {
 	DisplayBrand               string                        `json:"display_brand"`
 	SortOrder                  int                           `json:"sort_order"`
 	RateMultiplier             float64                       `json:"rate_multiplier"`
+	ImageRateIndependent       bool                          `json:"image_rate_independent"`
+	ImageRateMultiplier        float64                       `json:"image_rate_multiplier"`
 	OfficialPriceRatio         *float64                      `json:"official_price_ratio,omitempty"`
 	OfficialPriceRMBEquivalent *float64                      `json:"official_price_rmb_equivalent,omitempty"`
 	DataSharingEnabled         bool                          `json:"data_sharing_enabled"`
@@ -117,6 +119,8 @@ func ModelMarketplaceGroupsFromService(groups []service.ModelMarketplaceGroup) [
 			DisplayBrand:               group.DisplayBrand,
 			SortOrder:                  group.SortOrder,
 			RateMultiplier:             group.RateMultiplier,
+			ImageRateIndependent:       group.ImageRateIndependent,
+			ImageRateMultiplier:        group.ImageRateMultiplier,
 			OfficialPriceRatio:         group.OfficialPriceRatio,
 			OfficialPriceRMBEquivalent: group.OfficialPriceRMBEquivalent,
 			DataSharingEnabled:         group.DataSharingEnabled,

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -1255,16 +1255,23 @@ type ModelDisplayPricingInterval struct {
 // GetDisplayPricing 返回用于模型广场展示的价格信息。
 // 它会优先识别图片模型并展示按图计费，否则展示按 token 计费。
 func (s *BillingService) GetDisplayPricing(model string, rateMultiplier float64, groupConfig *ImagePriceConfig) ModelDisplayPricing {
+	return s.getDisplayPricing(model, rateMultiplier, rateMultiplier, groupConfig)
+}
+
+func (s *BillingService) getDisplayPricing(model string, rateMultiplier float64, imageRateMultiplier float64, groupConfig *ImagePriceConfig) ModelDisplayPricing {
 	if rateMultiplier < 0 {
 		rateMultiplier = 0
+	}
+	if imageRateMultiplier < 0 {
+		imageRateMultiplier = 0
 	}
 
 	rawPricing := s.getRawModelPricing(model)
 	if hasExplicitImagePricing(rawPricing) || looksLikeImageModel(model) {
 		return buildImageDisplayPricing(
-			s.getImageUnitPrice(model, "1K", groupConfig)*rateMultiplier,
-			s.getImageUnitPrice(model, "2K", groupConfig)*rateMultiplier,
-			s.getImageUnitPrice(model, "4K", groupConfig)*rateMultiplier,
+			s.getImageUnitPrice(model, "1K", groupConfig)*imageRateMultiplier,
+			s.getImageUnitPrice(model, "2K", groupConfig)*imageRateMultiplier,
+			s.getImageUnitPrice(model, "4K", groupConfig)*imageRateMultiplier,
 		)
 	}
 
@@ -1277,16 +1284,23 @@ func (s *BillingService) GetDisplayPricing(model string, rateMultiplier float64,
 }
 
 func (s *BillingService) getDisplayPricingWithResolved(model string, rateMultiplier float64, groupConfig *ImagePriceConfig, resolved *ResolvedPricing) ModelDisplayPricing {
+	return s.getDisplayPricingWithResolvedMultipliers(model, rateMultiplier, rateMultiplier, groupConfig, resolved)
+}
+
+func (s *BillingService) getDisplayPricingWithResolvedMultipliers(model string, rateMultiplier float64, imageRateMultiplier float64, groupConfig *ImagePriceConfig, resolved *ResolvedPricing) ModelDisplayPricing {
 	if rateMultiplier < 0 {
 		rateMultiplier = 0
 	}
-	if pricing, ok := displayPricingFromResolved(model, rateMultiplier, resolved); ok {
+	if imageRateMultiplier < 0 {
+		imageRateMultiplier = 0
+	}
+	if pricing, ok := displayPricingFromResolved(model, rateMultiplier, imageRateMultiplier, resolved); ok {
 		return pricing
 	}
-	return s.GetDisplayPricing(model, rateMultiplier, groupConfig)
+	return s.getDisplayPricing(model, rateMultiplier, imageRateMultiplier, groupConfig)
 }
 
-func displayPricingFromResolved(model string, rateMultiplier float64, resolved *ResolvedPricing) (ModelDisplayPricing, bool) {
+func displayPricingFromResolved(model string, rateMultiplier float64, imageRateMultiplier float64, resolved *ResolvedPricing) (ModelDisplayPricing, bool) {
 	if resolved == nil || resolved.Source != PricingSourceChannel {
 		return ModelDisplayPricing{}, false
 	}
@@ -1311,9 +1325,9 @@ func displayPricingFromResolved(model string, rateMultiplier float64, resolved *
 			return ModelDisplayPricing{}, false
 		}
 		return buildImageDisplayPricing(
-			price1K*rateMultiplier,
-			price2K*rateMultiplier,
-			price4K*rateMultiplier,
+			price1K*imageRateMultiplier,
+			price2K*imageRateMultiplier,
+			price4K*imageRateMultiplier,
 		), true
 	default:
 		return ModelDisplayPricing{}, false

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -1258,6 +1258,7 @@ func (s *BillingService) GetDisplayPricing(model string, rateMultiplier float64,
 	return s.getDisplayPricing(model, rateMultiplier, rateMultiplier, groupConfig)
 }
 
+// getDisplayPricing 按普通倍率和图片独立倍率计算模型广场展示价格。
 func (s *BillingService) getDisplayPricing(model string, rateMultiplier float64, imageRateMultiplier float64, groupConfig *ImagePriceConfig) ModelDisplayPricing {
 	if rateMultiplier < 0 {
 		rateMultiplier = 0
@@ -1283,10 +1284,7 @@ func (s *BillingService) getDisplayPricing(model string, rateMultiplier float64,
 	return buildTokenDisplayPricing(pricing, rateMultiplier)
 }
 
-func (s *BillingService) getDisplayPricingWithResolved(model string, rateMultiplier float64, groupConfig *ImagePriceConfig, resolved *ResolvedPricing) ModelDisplayPricing {
-	return s.getDisplayPricingWithResolvedMultipliers(model, rateMultiplier, rateMultiplier, groupConfig, resolved)
-}
-
+// getDisplayPricingWithResolvedMultipliers 优先使用已解析的渠道价格计算展示价格。
 func (s *BillingService) getDisplayPricingWithResolvedMultipliers(model string, rateMultiplier float64, imageRateMultiplier float64, groupConfig *ImagePriceConfig, resolved *ResolvedPricing) ModelDisplayPricing {
 	if rateMultiplier < 0 {
 		rateMultiplier = 0
@@ -1300,6 +1298,7 @@ func (s *BillingService) getDisplayPricingWithResolvedMultipliers(model string, 
 	return s.getDisplayPricing(model, rateMultiplier, imageRateMultiplier, groupConfig)
 }
 
+// displayPricingFromResolved 将已解析的渠道计费配置转换成模型广场展示价格。
 func displayPricingFromResolved(model string, rateMultiplier float64, imageRateMultiplier float64, resolved *ResolvedPricing) (ModelDisplayPricing, bool) {
 	if resolved == nil || resolved.Source != PricingSourceChannel {
 		return ModelDisplayPricing{}, false

--- a/backend/internal/service/model_marketplace_service.go
+++ b/backend/internal/service/model_marketplace_service.go
@@ -33,6 +33,8 @@ type ModelMarketplaceGroup struct {
 	DisplayBrand               string
 	SortOrder                  int
 	RateMultiplier             float64
+	ImageRateIndependent       bool
+	ImageRateMultiplier        float64
 	OfficialPriceRatio         *float64
 	OfficialPriceRMBEquivalent *float64
 	// DataSharingEnabled 标记公开分组是否会采集数据共享会话，供模型广场展示提示。
@@ -114,6 +116,8 @@ func (s *ModelMarketplaceService) ListPublic(ctx context.Context) ([]ModelMarket
 			DisplayBrand:               marketplaceGroupDisplayBrand(group),
 			SortOrder:                  group.SortOrder,
 			RateMultiplier:             group.RateMultiplier,
+			ImageRateIndependent:       group.ImageRateIndependent,
+			ImageRateMultiplier:        group.ImageRateMultiplier,
 			OfficialPriceRatio:         officialPriceRatio,
 			OfficialPriceRMBEquivalent: officialPriceRMBEquivalent,
 			DataSharingEnabled:         group.DataSharingEnabled,
@@ -352,15 +356,29 @@ func (s *ModelMarketplaceService) getPublicModelDisplayPricing(ctx context.Conte
 	if s.billingService == nil {
 		return unknownDisplayPricing()
 	}
+	imageRateMultiplier := marketplaceImageRateMultiplier(group)
 	if s.gatewayService != nil && s.gatewayService.resolver != nil {
 		groupID := group.ID
 		resolved := s.gatewayService.resolver.Resolve(ctx, PricingInput{
 			Model:   model,
 			GroupID: &groupID,
 		})
-		return s.billingService.getDisplayPricingWithResolved(model, group.RateMultiplier, imageConfig, resolved)
+		return s.billingService.getDisplayPricingWithResolvedMultipliers(model, group.RateMultiplier, imageRateMultiplier, imageConfig, resolved)
 	}
-	return s.billingService.GetDisplayPricing(model, group.RateMultiplier, imageConfig)
+	return s.billingService.getDisplayPricing(model, group.RateMultiplier, imageRateMultiplier, imageConfig)
+}
+
+func marketplaceImageRateMultiplier(group *Group) float64 {
+	if group == nil {
+		return 1
+	}
+	if !group.ImageRateIndependent {
+		return group.RateMultiplier
+	}
+	if group.ImageRateMultiplier < 0 {
+		return 0
+	}
+	return group.ImageRateMultiplier
 }
 
 func (s *ModelMarketplaceService) resolveGroupModels(ctx context.Context, group *Group) []marketplaceModelDef {

--- a/backend/internal/service/model_marketplace_service.go
+++ b/backend/internal/service/model_marketplace_service.go
@@ -368,6 +368,7 @@ func (s *ModelMarketplaceService) getPublicModelDisplayPricing(ctx context.Conte
 	return s.billingService.getDisplayPricing(model, group.RateMultiplier, imageRateMultiplier, imageConfig)
 }
 
+// marketplaceImageRateMultiplier 返回模型广场图片价格应使用的倍率。
 func marketplaceImageRateMultiplier(group *Group) float64 {
 	if group == nil {
 		return 1

--- a/backend/internal/service/model_marketplace_service_test.go
+++ b/backend/internal/service/model_marketplace_service_test.go
@@ -1,6 +1,9 @@
 package service
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestParseMarketplaceAvailabilityWindowSettings(t *testing.T) {
 	tests := []struct {
@@ -51,5 +54,55 @@ func TestParseMarketplaceAvailabilityWindowSettings(t *testing.T) {
 				t.Fatalf("parseMarketplaceAvailabilityWindowSettings() = (%d, %d), want (%d, %d)", gotWindowDays, gotBucketMinutes, tt.wantWindowDays, tt.wantBucketMinutes)
 			}
 		})
+	}
+}
+
+func TestModelMarketplaceDisplayPricing_UsesIndependentImageRateMultiplier(t *testing.T) {
+	image1K := 10.0
+	group := &Group{
+		ID:                   1,
+		RateMultiplier:       2.0,
+		ImageRateIndependent: true,
+		ImageRateMultiplier:  0.5,
+		ImagePrice1K:         &image1K,
+	}
+	svc := &ModelMarketplaceService{
+		billingService: &BillingService{},
+	}
+
+	pricing := svc.getPublicModelDisplayPricing(context.Background(), group, "gpt-image-1", &ImagePriceConfig{
+		Price1K: group.ImagePrice1K,
+	})
+
+	if pricing.PricingMode != "image" {
+		t.Fatalf("pricing mode = %q, want image", pricing.PricingMode)
+	}
+	if pricing.ImagePrice1K != 5 {
+		t.Fatalf("image 1K price = %v, want 5", pricing.ImagePrice1K)
+	}
+}
+
+func TestModelMarketplaceDisplayPricing_SharedImageRateUsesGroupMultiplier(t *testing.T) {
+	image1K := 10.0
+	group := &Group{
+		ID:                   1,
+		RateMultiplier:       2.0,
+		ImageRateIndependent: false,
+		ImageRateMultiplier:  0.5,
+		ImagePrice1K:         &image1K,
+	}
+	svc := &ModelMarketplaceService{
+		billingService: &BillingService{},
+	}
+
+	pricing := svc.getPublicModelDisplayPricing(context.Background(), group, "gpt-image-1", &ImagePriceConfig{
+		Price1K: group.ImagePrice1K,
+	})
+
+	if pricing.PricingMode != "image" {
+		t.Fatalf("pricing mode = %q, want image", pricing.PricingMode)
+	}
+	if pricing.ImagePrice1K != 20 {
+		t.Fatalf("image 1K price = %v, want 20", pricing.ImagePrice1K)
 	}
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -426,9 +426,9 @@ export default {
 
   marketplace: {
     title: 'Model Marketplace',
-    subtitle: 'Browse currently available models by public group, with actual charged pricing after the group multiplier is applied.',
+    subtitle: 'Browse currently available models by public group, with actual charged pricing after group and independent image multipliers are applied.',
     backHome: 'Back Home',
-    actualPricingNote: 'Prices are calculated from the pricing file base rates multiplied by the group multiplier, using {unitName}',
+    actualPricingNote: 'Prices are calculated from pricing file base rates multiplied by the group multiplier. When independent image pricing is enabled, image prices use the image multiplier instead. Unit: {unitName}',
     tokenPricing: 'Token Pricing',
     contextIntervalPricing: 'Context Interval Pricing',
     pricingDetail: 'Full Pricing Details',
@@ -461,6 +461,7 @@ export default {
     availabilityHintNoData: 'No active probe data in the last {days} days',
     rateMultiplier: 'Group Multiplier',
     rateMultiplierValue: 'Group Multiplier {multiplier}',
+    imageRateMultiplierValue: 'Image Multiplier {multiplier}',
     officialPriceDiscount: 'As low as {discount}/10 of official price',
     usdRmbEquivalent: 'As low as {amount} CNY equals 1 USD',
     contextTokens: 'Context Tokens',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -426,9 +426,9 @@ export default {
 
   marketplace: {
     title: '模型广场',
-    subtitle: '按公开分组浏览当前可用模型，并直接查看已包含分组倍率的实际扣费价格。',
+    subtitle: '按公开分组浏览当前可用模型，并直接查看已包含分组倍率和生图独立倍率的实际扣费价格。',
     backHome: '返回首页',
-    actualPricingNote: '价格已按价格文件记录的基础价乘以分组倍率计算，单位为 {unitName}',
+    actualPricingNote: '价格已按价格文件记录的基础价乘以分组倍率计算；生图独立倍率开启时，图片价格会改用生图倍率，单位为 {unitName}',
     tokenPricing: 'Token 计费',
     contextIntervalPricing: '按上下文区间定价',
     pricingDetail: '完整定价信息',
@@ -461,6 +461,7 @@ export default {
     availabilityHintNoData: '近 {days} 天暂无主动探测数据',
     rateMultiplier: '分组倍率',
     rateMultiplierValue: '分组倍率{multiplier}',
+    imageRateMultiplierValue: '生图倍率{multiplier}',
     officialPriceDiscount: '最低至官方价格的{discount}折',
     usdRmbEquivalent: '最低 {amount} 元相当于 1 美元',
     contextTokens: '上下文 Token',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -581,6 +581,8 @@ export interface MarketplaceGroup {
   display_brand: string
   sort_order: number
   rate_multiplier: number
+  image_rate_independent: boolean
+  image_rate_multiplier: number
   official_price_ratio?: number
   official_price_rmb_equivalent?: number
   // 数据共享分组需要在模型广场展示醒目标记，提醒用户该分组会进入采集流程。

--- a/frontend/src/views/ModelMarketplaceView.vue
+++ b/frontend/src/views/ModelMarketplaceView.vue
@@ -128,6 +128,12 @@
                   <span class="rounded-full border border-gray-200 bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-700 dark:border-dark-700 dark:bg-dark-900 dark:text-dark-200">
                     {{ formatRateMultiplierLabel(group.rate_multiplier) }}
                   </span>
+                  <span
+                    v-if="hasIndependentImageRate(group)"
+                    class="rounded-full border border-fuchsia-200 bg-fuchsia-50 px-3 py-1 text-xs font-semibold text-fuchsia-700 dark:border-fuchsia-500/30 dark:bg-fuchsia-500/10 dark:text-fuchsia-200"
+                  >
+                    {{ formatImageRateMultiplierLabel(group.image_rate_multiplier) }}
+                  </span>
                   <span class="rounded-full border border-gray-200 bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-700 dark:border-dark-700 dark:bg-dark-900 dark:text-dark-200">
                     {{ group.model_count }} {{ t('marketplace.modelsStat') }}
                   </span>
@@ -273,6 +279,12 @@
                     <h3 class="min-w-0 shrink-0 truncate text-sm font-semibold text-gray-950 dark:text-white">{{ entry.group.name }}</h3>
                     <span class="shrink-0 whitespace-nowrap rounded-full border border-gray-200 bg-white px-2 py-0.5 text-xs font-semibold text-gray-700 dark:border-dark-700 dark:bg-dark-900 dark:text-dark-200">
                       {{ formatMultiplier(entry.group.rate_multiplier) }}
+                    </span>
+                    <span
+                      v-if="hasIndependentImageRate(entry.group)"
+                      class="shrink-0 whitespace-nowrap rounded-full border border-fuchsia-200 bg-fuchsia-50 px-2 py-0.5 text-xs font-semibold text-fuchsia-700 dark:border-fuchsia-500/30 dark:bg-fuchsia-500/10 dark:text-fuchsia-200"
+                    >
+                      {{ formatImageRateMultiplierLabel(entry.group.image_rate_multiplier) }}
                     </span>
                     <div
                       v-if="entry.group.capacity"
@@ -756,6 +768,14 @@ function formatMultiplier(multiplier: number): string {
 // 分组倍率文案交给 i18n 拼接，避免不同语言的空格规则写死在模板里。
 function formatRateMultiplierLabel(multiplier: number): string {
   return t('marketplace.rateMultiplierValue', { multiplier: formatMultiplier(multiplier) })
+}
+
+function hasIndependentImageRate(group: Pick<MarketplaceGroup, 'image_rate_independent'>): boolean {
+  return Boolean(group.image_rate_independent)
+}
+
+function formatImageRateMultiplierLabel(multiplier: number): string {
+  return t('marketplace.imageRateMultiplierValue', { multiplier: formatMultiplier(multiplier) })
 }
 
 function formatPrice(value: number): string {

--- a/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
+++ b/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
@@ -47,6 +47,9 @@ vi.mock('vue-i18n', async () => {
         if (key === 'marketplace.rateMultiplierValue') {
           return `marketplace.rateMultiplierValue ${params?.multiplier || ''}`
         }
+        if (key === 'marketplace.imageRateMultiplierValue') {
+          return `marketplace.imageRateMultiplierValue ${params?.multiplier || ''}`
+        }
 
         return key
       },
@@ -127,6 +130,12 @@ const tokenPricing: MarketplaceModelPricing = {
   output_price_per_token: 0.000002,
 }
 
+const imagePricing: MarketplaceModelPricing = {
+  pricing_mode: 'image',
+  price_status: 'priced',
+  image_price_1k: 0.5,
+}
+
 const unpricedPricing: MarketplaceModelPricing = {
   pricing_mode: 'unknown',
   price_status: 'unpriced',
@@ -159,6 +168,8 @@ function marketplaceGroup(id: number, name: string, dataSharingEnabled: boolean,
     display_brand: 'OpenAI',
     sort_order: id,
     rate_multiplier: id,
+    image_rate_independent: false,
+    image_rate_multiplier: 1,
     official_price_ratio: id / 10,
     official_price_rmb_equivalent: id,
     data_sharing_enabled: dataSharingEnabled,
@@ -251,6 +262,28 @@ describe('ModelMarketplaceView', () => {
 
     const restored = await mountMarketplace()
     expect(restored.findAll('[data-testid="marketplace-group-section"]')).toHaveLength(4)
+  })
+
+  it('展示开启独立配置的生图倍率', async () => {
+    const fixture = marketplaceFixture()
+    fixture[0] = {
+      ...fixture[0],
+      image_rate_independent: true,
+      image_rate_multiplier: 0.5,
+      models: [
+        marketplaceModel('gpt-image-1', 'GPT Image', imagePricing),
+      ],
+    }
+    getMarketplaceModels.mockResolvedValue(fixture)
+
+    const wrapper = await mountMarketplace()
+
+    expect(modelCards(wrapper).map((card) => card.text()).join('\n')).toContain('marketplace.imageRateMultiplierValue x0.50')
+
+    await wrapper.get('[data-testid="select-option-group-model"]').trigger('click')
+    await nextTick()
+
+    expect(wrapper.findAll('[data-testid="marketplace-group-section"]').map((section) => section.text()).join('\n')).toContain('marketplace.imageRateMultiplierValue x0.50')
   })
 
   it('模型-分组模式下按分组、搜索和计费类型裁剪分组条目', async () => {


### PR DESCRIPTION
## 摘要
- 修复分组启用“生图独立倍率”时，模型广场图片模型价格仍按普通分组倍率计算的问题
- 在模型广场分组 DTO 中透出图片独立倍率相关字段
- 在模型广场分组展示中增加明确的“生图倍率”标签

## 测试
- go test -tags unit ./internal/service -run "TestModelMarketplaceDisplayPricing|TestParseMarketplaceAvailabilityWindowSettings" -count=1
- go test -tags unit ./internal/handler/dto -count=1
- node_modules\.bin\vitest.cmd run src/views/__tests__/ModelMarketplaceView.spec.ts