### PR TITLE
fix(data-sharing): refresh export upload progress

### DIFF
--- a/frontend/src/api/admin/dataSharing.ts
+++ b/frontend/src/api/admin/dataSharing.ts
@@ -349,6 +349,12 @@ export async function listExportArtifacts(
   return data
 }
 
+// 获取单个导出任务的最新状态，供远端上传进度轮询使用。
+export async function getExportArtifact(id: number): Promise<DataShareExportArtifact> {
+  const { data } = await apiClient.get<DataShareExportArtifact>(`/admin/data-sharing/exports/${id}`)
+  return data
+}
+
 export async function createExportArtifactDownloadTicket(id: number): Promise<DataShareExportTicket> {
   const { data } = await apiClient.post<DataShareExportTicket>(`/admin/data-sharing/exports/${id}/download-ticket`)
   return data
@@ -401,6 +407,7 @@ export const adminDataSharingAPI = {
   createExportArtifact,
   createSessionExportArtifact,
   listExportArtifacts,
+  getExportArtifact,
   createExportArtifactDownloadTicket,
   uploadExportArtifact,
   cancelExportArtifactUpload,

--- a/frontend/src/views/admin/DataSharingView.vue
+++ b/frontend/src/views/admin/DataSharingView.vue
@@ -1288,6 +1288,7 @@ const exportUploadConcurrencyDefault = 4
 const exportUploadPartSizeMBMin = 5
 const exportUploadPartSizeMBMax = 128
 const exportUploadPartSizeMBDefault = 64
+const exportArtifactUploadPollingIntervalMs = 2000
 const statsAutoRefreshDefaultSeconds = 5
 const statsAutoRefreshIntervals = [5, 10, 15, 30] as const
 const captureCompressionLevelOptions = [
@@ -2058,6 +2059,9 @@ const cancelUploadDialogMessage = computed(() => {
 
 let filterTimer: number | null = null
 let statsAutoRefreshTimer: number | null = null
+let exportArtifactUploadPollingTimer: number | null = null
+let exportArtifactUploadPollingID: number | null = null
+let exportArtifactUploadPollInFlight = false
 
 function buildFilters(): AdminDataShareSessionFilters {
   const out: AdminDataShareSessionFilters = {
@@ -2659,7 +2663,7 @@ async function loadExportArtifacts() {
     exportArtifacts.value = res.items
     exportArtifactPagination.total = res.total
     exportArtifactPagination.pages = res.pages
-    // 导出文件状态只在页面加载、手动刷新和任务操作后刷新，避免后台自动轮询。
+    syncExportArtifactUploadPolling(res.items)
   } catch (error) {
     appStore.showError('加载导出文件失败')
   } finally {
@@ -2669,6 +2673,64 @@ async function loadExportArtifacts() {
 
 async function refreshExportArtifacts() {
   await Promise.all([loadExportArtifacts(), loadStats()])
+}
+
+function syncExportArtifactUploadPolling(items: DataShareExportArtifact[]) {
+  // 后端当前只允许一个远端上传任务，因此只跟踪当前页面上的上传中任务。
+  const uploading = items.find(item => item.remote_status === 'uploading')
+  if (!uploading) {
+    stopExportArtifactUploadPolling()
+    return
+  }
+  startExportArtifactUploadPolling(uploading.id)
+}
+
+function startExportArtifactUploadPolling(id: number) {
+  if (id <= 0 || document.hidden) return
+  if (exportArtifactUploadPollingTimer && exportArtifactUploadPollingID === id) return
+  stopExportArtifactUploadPolling()
+  exportArtifactUploadPollingID = id
+  exportArtifactUploadPollingTimer = window.setInterval(
+    pollExportArtifactUpload,
+    exportArtifactUploadPollingIntervalMs
+  )
+}
+
+function stopExportArtifactUploadPolling(id?: number) {
+  if (id && exportArtifactUploadPollingID !== id) return
+  if (exportArtifactUploadPollingTimer) {
+    window.clearInterval(exportArtifactUploadPollingTimer)
+  }
+  exportArtifactUploadPollingTimer = null
+  exportArtifactUploadPollingID = null
+}
+
+async function pollExportArtifactUpload() {
+  const id = exportArtifactUploadPollingID
+  if (!exportArtifactUploadPollingTimer || !id || document.hidden || exportArtifactUploadPollInFlight) return
+  exportArtifactUploadPollInFlight = true
+  try {
+    const artifact = await adminDataSharingAPI.getExportArtifact(id)
+    // 取消、切换任务或卸载后，忽略已经在途的旧响应。
+    if (exportArtifactUploadPollingID !== id) return
+    replaceExportArtifact(artifact)
+    if (artifact.remote_status !== 'uploading') {
+      stopExportArtifactUploadPolling(id)
+    }
+  } catch {
+    // 短暂网络错误不终止轮询，管理员仍可使用手动刷新或取消上传。
+  } finally {
+    exportArtifactUploadPollInFlight = false
+  }
+}
+
+async function handleExportArtifactVisibilityChange() {
+  if (document.hidden) {
+    stopExportArtifactUploadPolling()
+    return
+  }
+  // 标签页恢复时重新读取持久化状态，再按最新状态决定是否继续轮询。
+  await loadExportArtifacts()
 }
 
 function refreshAll() {
@@ -2897,6 +2959,7 @@ async function uploadExportArtifact(row: DataShareExportArtifact) {
   try {
     const artifact = await adminDataSharingAPI.uploadExportArtifact(row.id)
     replaceExportArtifact(artifact)
+    startExportArtifactUploadPolling(artifact.id)
     appStore.showSuccess('上传任务已开始')
   } catch (error) {
     appStore.showError('启动上传到 S3/R2 失败')
@@ -2948,6 +3011,7 @@ async function confirmCancelExportArtifactUpload() {
     // 取消只中断远端上传任务，本地生成好的导出文件仍保留，可稍后重新上传。
     const artifact = await adminDataSharingAPI.cancelExportArtifactUpload(target.id)
     replaceExportArtifact(artifact)
+    stopExportArtifactUploadPolling(target.id)
     appStore.showSuccess('上传任务已取消')
   } catch (error) {
     appStore.showError('取消上传失败')
@@ -3295,6 +3359,7 @@ function formatExportUploadSpeed(bytesPerSecond?: number | null) {
 onMounted(() => {
   document.addEventListener('click', closeSkipRulePathMenuOnOutsideClick)
   document.addEventListener('click', closeStatsAutoRefreshDropdownOnOutsideClick)
+  document.addEventListener('visibilitychange', handleExportArtifactVisibilityChange)
   window.addEventListener('resize', handleStatsAutoRefreshViewportChange)
   window.addEventListener('scroll', handleStatsAutoRefreshViewportChange, true)
   loadFilterOptions()
@@ -3309,8 +3374,10 @@ onMounted(() => {
 onUnmounted(() => {
   document.removeEventListener('click', closeSkipRulePathMenuOnOutsideClick)
   document.removeEventListener('click', closeStatsAutoRefreshDropdownOnOutsideClick)
+  document.removeEventListener('visibilitychange', handleExportArtifactVisibilityChange)
   window.removeEventListener('resize', handleStatsAutoRefreshViewportChange)
   window.removeEventListener('scroll', handleStatsAutoRefreshViewportChange, true)
   stopStatsAutoRefresh()
+  stopExportArtifactUploadPolling()
 })
 </script>

--- a/frontend/src/views/admin/__tests__/DataSharingView.uploadPolling.spec.ts
+++ b/frontend/src/views/admin/__tests__/DataSharingView.uploadPolling.spec.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import DataSharingView from '../DataSharingView.vue'
+
+const adminDataSharingAPI = vi.hoisted(() => ({
+  getNotice: vi.fn(),
+  getSkipRules: vi.fn(),
+  getStorageLimit: vi.fn(),
+  getRuntimeSettings: vi.fn(),
+  getExportRemoteConfig: vi.fn(),
+  getFilterOptions: vi.fn(),
+  listSessions: vi.fn(),
+  listExportArtifacts: vi.fn(),
+  getExportArtifact: vi.fn(),
+  getStats: vi.fn(),
+  updateNotice: vi.fn(),
+  updateSkipRules: vi.fn(),
+  updateStorageLimit: vi.fn(),
+  updateRuntimeSettings: vi.fn(),
+  updateExportRemoteConfig: vi.fn(),
+  testExportRemoteConfig: vi.fn(),
+  getSession: vi.fn(),
+  deleteSession: vi.fn(),
+  batchDeleteSessions: vi.fn(),
+  createExportArtifact: vi.fn(),
+  createSessionExportArtifact: vi.fn(),
+  createExportArtifactDownloadTicket: vi.fn(),
+  uploadExportArtifact: vi.fn(),
+  cancelExportArtifactUpload: vi.fn(),
+  getExportArtifactRemoteDownloadURL: vi.fn(),
+  deleteExportArtifact: vi.fn()
+}))
+
+vi.mock('@/api/admin/dataSharing', () => ({
+  adminDataSharingAPI,
+  default: adminDataSharingAPI
+}))
+
+vi.mock('@/api/dataSharing', () => ({
+  dataSharingAPI: { startTicketDownload: vi.fn() },
+  default: { startTicketDownload: vi.fn() }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/useBalanceDisplay', () => ({
+  useBalanceDisplay: () => ({
+    balanceUnitName: '余额',
+    formatBalanceAmount: (value: number) => String(value)
+  })
+}))
+
+vi.mock('@/composables/useClipboard', () => ({
+  useClipboard: () => ({ copyToClipboard: vi.fn() })
+}))
+
+vi.mock('vue-i18n', async importOriginal => {
+  const actual = await importOriginal<typeof import('vue-i18n')>()
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+      te: () => false
+    })
+  }
+})
+
+vi.mock('chart.js', () => ({
+  Chart: { register: vi.fn() },
+  CategoryScale: {},
+  LinearScale: {},
+  PointElement: {},
+  LineElement: {},
+  BarElement: {},
+  ArcElement: {},
+  Tooltip: {},
+  Legend: {},
+  Filler: {}
+}))
+
+vi.mock('vue-chartjs', () => ({
+  Bar: { template: '<div />' },
+  Doughnut: { template: '<div />' },
+  Line: { template: '<div />' }
+}))
+
+const DataTableStub = {
+  props: ['data'],
+  template: `
+    <div>
+      <div v-for="row in data" :key="row.id" data-test="data-table-row">
+        <slot name="cell-remote_status" :row="row" :value="row.remote_status" />
+        <slot name="cell-actions" :row="row" :value="row.actions" />
+      </div>
+    </div>
+  `
+}
+
+function createArtifact(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 42,
+    status: 'completed',
+    filename: 'export.jsonl.zst',
+    encoding: 'zstd',
+    session_count: 100,
+    file_size: 100_000_000,
+    sha256: 'abc123',
+    error_message: '',
+    remote_status: 'uploading',
+    remote_bucket: '',
+    remote_key: '',
+    remote_error_message: '',
+    remote_uploaded_at: null,
+    remote_upload_bytes: 0,
+    remote_upload_speed: 0,
+    generate_progress_done: 100,
+    generate_progress_total: 100,
+    generate_progress_percent: 100,
+    created_at: '2026-07-14T00:00:00Z',
+    started_at: '2026-07-14T00:00:00Z',
+    completed_at: '2026-07-14T00:01:00Z',
+    deleted_at: null,
+    updated_at: '2026-07-14T00:01:00Z',
+    ...overrides
+  }
+}
+
+function mountView() {
+  return mount(DataSharingView, {
+    global: {
+      stubs: {
+        AppLayout: { template: '<div><slot /></div>' },
+        TablePageLayout: {
+          template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /><slot /></div>'
+        },
+        DataTable: DataTableStub,
+        Pagination: true,
+        Select: true,
+        EmptyState: true,
+        BaseDialog: true,
+        ConfirmDialog: true,
+        LoadingSpinner: true,
+        Icon: true,
+        Teleport: true
+      }
+    }
+  })
+}
+
+function setDocumentHidden(hidden: boolean) {
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    value: hidden
+  })
+}
+
+describe('admin DataSharingView export upload polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setDocumentHidden(false)
+    Object.values(adminDataSharingAPI).forEach(mock => mock.mockReset())
+
+    adminDataSharingAPI.getNotice.mockResolvedValue({ content: '', version: 1 })
+    adminDataSharingAPI.getSkipRules.mockResolvedValue([])
+    adminDataSharingAPI.getStorageLimit.mockResolvedValue({ limit_bytes: 0 })
+    adminDataSharingAPI.getRuntimeSettings.mockResolvedValue({
+      worker_count: 1,
+      queue_size: 1,
+      flush_queue_size: 1,
+      task_timeout_seconds: 1,
+      compression_level: 'fastest',
+      buffer_enabled: true,
+      buffer_idle_flush_seconds: 30,
+      buffer_max_sessions: 4096,
+      buffer_max_pending_events: 65536,
+      duration_window_size: 512,
+      export_batch_size: 500,
+      export_worker_count: 4
+    })
+    adminDataSharingAPI.getExportRemoteConfig.mockResolvedValue({
+      endpoint: '',
+      region: 'auto',
+      bucket: '',
+      access_key_id: '',
+      prefix: 'data-sharing-exports',
+      force_path_style: false,
+      upload_concurrency: 4,
+      upload_part_size_mb: 64
+    })
+    adminDataSharingAPI.getFilterOptions.mockResolvedValue({ models: [], request_paths: [], user_agents: [] })
+    adminDataSharingAPI.listSessions.mockResolvedValue({ items: [], total: 0, page: 1, page_size: 20, pages: 1 })
+    adminDataSharingAPI.getStats.mockResolvedValue({
+      storage_trend: [],
+      group_storage_breakdown: [],
+      request_path_breakdown: [],
+      model_breakdown: [],
+      user_agent_breakdown: [],
+      quality_error_breakdown: [],
+      invalid_user_breakdown: []
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete (document as Document & { hidden?: boolean }).hidden
+  })
+
+  it('starts polling after upload and refreshes until the terminal status is returned', async () => {
+    adminDataSharingAPI.listExportArtifacts.mockResolvedValue({
+      items: [createArtifact({ remote_status: 'not_uploaded' })],
+      total: 1,
+      page: 1,
+      page_size: 10,
+      pages: 1
+    })
+    adminDataSharingAPI.uploadExportArtifact.mockResolvedValue(createArtifact())
+    adminDataSharingAPI.getExportArtifact
+      .mockResolvedValueOnce(createArtifact({ remote_upload_bytes: 25_000_000, remote_upload_speed: 5_000_000 }))
+      .mockResolvedValueOnce(createArtifact({ remote_status: 'uploaded', remote_bucket: 'bucket-a', remote_key: 'exports/file.zst' }))
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const uploadButton = wrapper.findAll('button').find(button => button.text().trim() === '上传')
+    expect(uploadButton).toBeDefined()
+    await uploadButton!.trigger('click')
+    await flushPromises()
+
+    expect(adminDataSharingAPI.uploadExportArtifact).toHaveBeenCalledWith(42)
+    expect(wrapper.text()).toContain('0.00% · 0.00 MB/s')
+
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+
+    expect(adminDataSharingAPI.getExportArtifact).toHaveBeenCalledWith(42)
+    expect(wrapper.text()).toContain('25.0% · 5.00 MB/s')
+
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('已上传')
+    expect(adminDataSharingAPI.getExportArtifact).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(adminDataSharingAPI.getExportArtifact).toHaveBeenCalledTimes(2)
+    wrapper.unmount()
+  })
+
+  it('does not overlap upload status requests when one poll is still pending', async () => {
+    adminDataSharingAPI.listExportArtifacts.mockResolvedValue({
+      items: [createArtifact()],
+      total: 1,
+      page: 1,
+      page_size: 10,
+      pages: 1
+    })
+    let resolveFirstPoll: (artifact: ReturnType<typeof createArtifact>) => void = () => {}
+    adminDataSharingAPI.getExportArtifact
+      .mockReturnValueOnce(new Promise(resolve => {
+        resolveFirstPoll = resolve
+      }))
+      .mockResolvedValueOnce(createArtifact({ remote_status: 'uploaded' }))
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(adminDataSharingAPI.getExportArtifact).toHaveBeenCalledTimes(1)
+
+    resolveFirstPoll(createArtifact({ remote_upload_bytes: 10_000_000, remote_upload_speed: 2_000_000 }))
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+
+    expect(adminDataSharingAPI.getExportArtifact).toHaveBeenCalledTimes(2)
+    wrapper.unmount()
+  })
+
+  it('pauses while hidden, resumes when visible, and stops after unmount', async () => {
+    adminDataSharingAPI.listExportArtifacts.mockResolvedValue({
+      items: [createArtifact()],
+      total: 1,
+      page: 1,
+      page_size: 10,
+      pages: 1
+    })
+    adminDataSharingAPI.getExportArtifact.mockResolvedValue(createArtifact({
+      remote_upload_bytes: 10_000_000,
+      remote_upload_speed: 2_000_000
+    }))
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    setDocumentHidden(true)
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(adminDataSharingAPI.getExportArtifact).not.toHaveBeenCalled()
+
+    setDocumentHidden(false)
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+    expect(adminDataSharingAPI.getExportArtifact).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(adminDataSharingAPI.getExportArtifact).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- poll the existing per-artifact endpoint while an S3/R2 export upload is active
- update upload bytes and speed without reloading the full export table
- pause polling for hidden tabs and stop on terminal status or component unmount
- add coverage for upload start, progress updates, request deduplication, and lifecycle cleanup

## Testing

- `pnpm exec vitest run src/views/admin/__tests__/DataSharingView.uploadPolling.spec.ts`
- `pnpm typecheck`
- `pnpm exec eslint src/api/admin/dataSharing.ts src/views/admin/DataSharingView.vue src/views/admin/__tests__/DataSharingView.uploadPolling.spec.ts`
- `pnpm build`
- `go test ./internal/repository -run 'TestS3BackupStoreUploadFileWithProgress|TestS3UploadConfigNormalizers' -count=1`\n- `go test ./internal/service -run 'TestDataSharingService_(UploadExportArtifactToRemoteAndPresignURL|ListExportArtifactsMergesUploadProgress)' -count=1`