### PR TITLE
feat(api-keys): add per-key Fast mode policy

### DIFF
--- a/backend/ent/apikey.go
+++ b/backend/ent/apikey.go
@@ -36,6 +36,8 @@ type APIKey struct {
 	GroupID *int64 `json:"group_id,omitempty"`
 	// Status holds the value of the "status" field.
 	Status string `json:"status,omitempty"`
+	// API Key 的 Fast 模式策略：follow_request、force_on 或 force_off
+	FastModePolicy string `json:"fast_mode_policy,omitempty"`
 	// Last usage time of this API key
 	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
 	// Allowed IPs/CIDRs, e.g. ["192.168.1.100", "10.0.0.0/8"]
@@ -137,7 +139,7 @@ func (*APIKey) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullFloat64)
 		case apikey.FieldID, apikey.FieldUserID, apikey.FieldGroupID, apikey.FieldDataSharingNoticeVersion, apikey.FieldDataSharingConfirmedGroupID:
 			values[i] = new(sql.NullInt64)
-		case apikey.FieldKey, apikey.FieldName, apikey.FieldStatus:
+		case apikey.FieldKey, apikey.FieldName, apikey.FieldStatus, apikey.FieldFastModePolicy:
 			values[i] = new(sql.NullString)
 		case apikey.FieldCreatedAt, apikey.FieldUpdatedAt, apikey.FieldDeletedAt, apikey.FieldLastUsedAt, apikey.FieldExpiresAt, apikey.FieldWindow5hStart, apikey.FieldWindow1dStart, apikey.FieldWindow7dStart, apikey.FieldDataSharingConfirmedAt:
 			values[i] = new(sql.NullTime)
@@ -211,6 +213,12 @@ func (_m *APIKey) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field status", values[i])
 			} else if value.Valid {
 				_m.Status = value.String
+			}
+		case apikey.FieldFastModePolicy:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field fast_mode_policy", values[i])
+			} else if value.Valid {
+				_m.FastModePolicy = value.String
 			}
 		case apikey.FieldLastUsedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -415,6 +423,9 @@ func (_m *APIKey) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("status=")
 	builder.WriteString(_m.Status)
+	builder.WriteString(", ")
+	builder.WriteString("fast_mode_policy=")
+	builder.WriteString(_m.FastModePolicy)
 	builder.WriteString(", ")
 	if v := _m.LastUsedAt; v != nil {
 		builder.WriteString("last_used_at=")

--- a/backend/ent/apikey/apikey.go
+++ b/backend/ent/apikey/apikey.go
@@ -31,6 +31,8 @@ const (
 	FieldGroupID = "group_id"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
+	// FieldFastModePolicy holds the string denoting the fast_mode_policy field in the database.
+	FieldFastModePolicy = "fast_mode_policy"
 	// FieldLastUsedAt holds the string denoting the last_used_at field in the database.
 	FieldLastUsedAt = "last_used_at"
 	// FieldIPWhitelist holds the string denoting the ip_whitelist field in the database.
@@ -111,6 +113,7 @@ var Columns = []string{
 	FieldName,
 	FieldGroupID,
 	FieldStatus,
+	FieldFastModePolicy,
 	FieldLastUsedAt,
 	FieldIPWhitelist,
 	FieldIPBlacklist,
@@ -164,6 +167,10 @@ var (
 	DefaultStatus string
 	// StatusValidator is a validator for the "status" field. It is called by the builders before save.
 	StatusValidator func(string) error
+	// DefaultFastModePolicy holds the default value on creation for the "fast_mode_policy" field.
+	DefaultFastModePolicy string
+	// FastModePolicyValidator is a validator for the "fast_mode_policy" field. It is called by the builders before save.
+	FastModePolicyValidator func(string) error
 	// DefaultQuota holds the default value on creation for the "quota" field.
 	DefaultQuota float64
 	// DefaultQuotaUsed holds the default value on creation for the "quota_used" field.
@@ -232,6 +239,11 @@ func ByGroupID(opts ...sql.OrderTermOption) OrderOption {
 // ByStatus orders the results by the status field.
 func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
+}
+
+// ByFastModePolicy orders the results by the fast_mode_policy field.
+func ByFastModePolicy(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFastModePolicy, opts...).ToFunc()
 }
 
 // ByLastUsedAt orders the results by the last_used_at field.

--- a/backend/ent/apikey/where.go
+++ b/backend/ent/apikey/where.go
@@ -95,6 +95,11 @@ func Status(v string) predicate.APIKey {
 	return predicate.APIKey(sql.FieldEQ(FieldStatus, v))
 }
 
+// FastModePolicy applies equality check predicate on the "fast_mode_policy" field. It's identical to FastModePolicyEQ.
+func FastModePolicy(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldEQ(FieldFastModePolicy, v))
+}
+
 // LastUsedAt applies equality check predicate on the "last_used_at" field. It's identical to LastUsedAtEQ.
 func LastUsedAt(v time.Time) predicate.APIKey {
 	return predicate.APIKey(sql.FieldEQ(FieldLastUsedAt, v))
@@ -553,6 +558,71 @@ func StatusEqualFold(v string) predicate.APIKey {
 // StatusContainsFold applies the ContainsFold predicate on the "status" field.
 func StatusContainsFold(v string) predicate.APIKey {
 	return predicate.APIKey(sql.FieldContainsFold(FieldStatus, v))
+}
+
+// FastModePolicyEQ applies the EQ predicate on the "fast_mode_policy" field.
+func FastModePolicyEQ(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldEQ(FieldFastModePolicy, v))
+}
+
+// FastModePolicyNEQ applies the NEQ predicate on the "fast_mode_policy" field.
+func FastModePolicyNEQ(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldNEQ(FieldFastModePolicy, v))
+}
+
+// FastModePolicyIn applies the In predicate on the "fast_mode_policy" field.
+func FastModePolicyIn(vs ...string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldIn(FieldFastModePolicy, vs...))
+}
+
+// FastModePolicyNotIn applies the NotIn predicate on the "fast_mode_policy" field.
+func FastModePolicyNotIn(vs ...string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldNotIn(FieldFastModePolicy, vs...))
+}
+
+// FastModePolicyGT applies the GT predicate on the "fast_mode_policy" field.
+func FastModePolicyGT(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldGT(FieldFastModePolicy, v))
+}
+
+// FastModePolicyGTE applies the GTE predicate on the "fast_mode_policy" field.
+func FastModePolicyGTE(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldGTE(FieldFastModePolicy, v))
+}
+
+// FastModePolicyLT applies the LT predicate on the "fast_mode_policy" field.
+func FastModePolicyLT(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldLT(FieldFastModePolicy, v))
+}
+
+// FastModePolicyLTE applies the LTE predicate on the "fast_mode_policy" field.
+func FastModePolicyLTE(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldLTE(FieldFastModePolicy, v))
+}
+
+// FastModePolicyContains applies the Contains predicate on the "fast_mode_policy" field.
+func FastModePolicyContains(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldContains(FieldFastModePolicy, v))
+}
+
+// FastModePolicyHasPrefix applies the HasPrefix predicate on the "fast_mode_policy" field.
+func FastModePolicyHasPrefix(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldHasPrefix(FieldFastModePolicy, v))
+}
+
+// FastModePolicyHasSuffix applies the HasSuffix predicate on the "fast_mode_policy" field.
+func FastModePolicyHasSuffix(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldHasSuffix(FieldFastModePolicy, v))
+}
+
+// FastModePolicyEqualFold applies the EqualFold predicate on the "fast_mode_policy" field.
+func FastModePolicyEqualFold(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldEqualFold(FieldFastModePolicy, v))
+}
+
+// FastModePolicyContainsFold applies the ContainsFold predicate on the "fast_mode_policy" field.
+func FastModePolicyContainsFold(v string) predicate.APIKey {
+	return predicate.APIKey(sql.FieldContainsFold(FieldFastModePolicy, v))
 }
 
 // LastUsedAtEQ applies the EQ predicate on the "last_used_at" field.

--- a/backend/ent/apikey_create.go
+++ b/backend/ent/apikey_create.go
@@ -113,6 +113,20 @@ func (_c *APIKeyCreate) SetNillableStatus(v *string) *APIKeyCreate {
 	return _c
 }
 
+// SetFastModePolicy sets the "fast_mode_policy" field.
+func (_c *APIKeyCreate) SetFastModePolicy(v string) *APIKeyCreate {
+	_c.mutation.SetFastModePolicy(v)
+	return _c
+}
+
+// SetNillableFastModePolicy sets the "fast_mode_policy" field if the given value is not nil.
+func (_c *APIKeyCreate) SetNillableFastModePolicy(v *string) *APIKeyCreate {
+	if v != nil {
+		_c.SetFastModePolicy(*v)
+	}
+	return _c
+}
+
 // SetLastUsedAt sets the "last_used_at" field.
 func (_c *APIKeyCreate) SetLastUsedAt(v time.Time) *APIKeyCreate {
 	_c.mutation.SetLastUsedAt(v)
@@ -443,6 +457,10 @@ func (_c *APIKeyCreate) defaults() error {
 		v := apikey.DefaultStatus
 		_c.mutation.SetStatus(v)
 	}
+	if _, ok := _c.mutation.FastModePolicy(); !ok {
+		v := apikey.DefaultFastModePolicy
+		_c.mutation.SetFastModePolicy(v)
+	}
 	if _, ok := _c.mutation.Quota(); !ok {
 		v := apikey.DefaultQuota
 		_c.mutation.SetQuota(v)
@@ -519,6 +537,14 @@ func (_c *APIKeyCreate) check() error {
 	if v, ok := _c.mutation.Status(); ok {
 		if err := apikey.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "APIKey.status": %w`, err)}
+		}
+	}
+	if _, ok := _c.mutation.FastModePolicy(); !ok {
+		return &ValidationError{Name: "fast_mode_policy", err: errors.New(`ent: missing required field "APIKey.fast_mode_policy"`)}
+	}
+	if v, ok := _c.mutation.FastModePolicy(); ok {
+		if err := apikey.FastModePolicyValidator(v); err != nil {
+			return &ValidationError{Name: "fast_mode_policy", err: fmt.Errorf(`ent: validator failed for field "APIKey.fast_mode_policy": %w`, err)}
 		}
 	}
 	if _, ok := _c.mutation.Quota(); !ok {
@@ -604,6 +630,10 @@ func (_c *APIKeyCreate) createSpec() (*APIKey, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.Status(); ok {
 		_spec.SetField(apikey.FieldStatus, field.TypeString, value)
 		_node.Status = value
+	}
+	if value, ok := _c.mutation.FastModePolicy(); ok {
+		_spec.SetField(apikey.FieldFastModePolicy, field.TypeString, value)
+		_node.FastModePolicy = value
 	}
 	if value, ok := _c.mutation.LastUsedAt(); ok {
 		_spec.SetField(apikey.FieldLastUsedAt, field.TypeTime, value)
@@ -876,6 +906,18 @@ func (u *APIKeyUpsert) SetStatus(v string) *APIKeyUpsert {
 // UpdateStatus sets the "status" field to the value that was provided on create.
 func (u *APIKeyUpsert) UpdateStatus() *APIKeyUpsert {
 	u.SetExcluded(apikey.FieldStatus)
+	return u
+}
+
+// SetFastModePolicy sets the "fast_mode_policy" field.
+func (u *APIKeyUpsert) SetFastModePolicy(v string) *APIKeyUpsert {
+	u.Set(apikey.FieldFastModePolicy, v)
+	return u
+}
+
+// UpdateFastModePolicy sets the "fast_mode_policy" field to the value that was provided on create.
+func (u *APIKeyUpsert) UpdateFastModePolicy() *APIKeyUpsert {
+	u.SetExcluded(apikey.FieldFastModePolicy)
 	return u
 }
 
@@ -1375,6 +1417,20 @@ func (u *APIKeyUpsertOne) SetStatus(v string) *APIKeyUpsertOne {
 func (u *APIKeyUpsertOne) UpdateStatus() *APIKeyUpsertOne {
 	return u.Update(func(s *APIKeyUpsert) {
 		s.UpdateStatus()
+	})
+}
+
+// SetFastModePolicy sets the "fast_mode_policy" field.
+func (u *APIKeyUpsertOne) SetFastModePolicy(v string) *APIKeyUpsertOne {
+	return u.Update(func(s *APIKeyUpsert) {
+		s.SetFastModePolicy(v)
+	})
+}
+
+// UpdateFastModePolicy sets the "fast_mode_policy" field to the value that was provided on create.
+func (u *APIKeyUpsertOne) UpdateFastModePolicy() *APIKeyUpsertOne {
+	return u.Update(func(s *APIKeyUpsert) {
+		s.UpdateFastModePolicy()
 	})
 }
 
@@ -2097,6 +2153,20 @@ func (u *APIKeyUpsertBulk) SetStatus(v string) *APIKeyUpsertBulk {
 func (u *APIKeyUpsertBulk) UpdateStatus() *APIKeyUpsertBulk {
 	return u.Update(func(s *APIKeyUpsert) {
 		s.UpdateStatus()
+	})
+}
+
+// SetFastModePolicy sets the "fast_mode_policy" field.
+func (u *APIKeyUpsertBulk) SetFastModePolicy(v string) *APIKeyUpsertBulk {
+	return u.Update(func(s *APIKeyUpsert) {
+		s.SetFastModePolicy(v)
+	})
+}
+
+// UpdateFastModePolicy sets the "fast_mode_policy" field to the value that was provided on create.
+func (u *APIKeyUpsertBulk) UpdateFastModePolicy() *APIKeyUpsertBulk {
+	return u.Update(func(s *APIKeyUpsert) {
+		s.UpdateFastModePolicy()
 	})
 }
 

--- a/backend/ent/apikey_update.go
+++ b/backend/ent/apikey_update.go
@@ -134,6 +134,20 @@ func (_u *APIKeyUpdate) SetNillableStatus(v *string) *APIKeyUpdate {
 	return _u
 }
 
+// SetFastModePolicy sets the "fast_mode_policy" field.
+func (_u *APIKeyUpdate) SetFastModePolicy(v string) *APIKeyUpdate {
+	_u.mutation.SetFastModePolicy(v)
+	return _u
+}
+
+// SetNillableFastModePolicy sets the "fast_mode_policy" field if the given value is not nil.
+func (_u *APIKeyUpdate) SetNillableFastModePolicy(v *string) *APIKeyUpdate {
+	if v != nil {
+		_u.SetFastModePolicy(*v)
+	}
+	return _u
+}
+
 // SetLastUsedAt sets the "last_used_at" field.
 func (_u *APIKeyUpdate) SetLastUsedAt(v time.Time) *APIKeyUpdate {
 	_u.mutation.SetLastUsedAt(v)
@@ -642,6 +656,11 @@ func (_u *APIKeyUpdate) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "APIKey.status": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FastModePolicy(); ok {
+		if err := apikey.FastModePolicyValidator(v); err != nil {
+			return &ValidationError{Name: "fast_mode_policy", err: fmt.Errorf(`ent: validator failed for field "APIKey.fast_mode_policy": %w`, err)}
+		}
+	}
 	if _u.mutation.UserCleared() && len(_u.mutation.UserIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "APIKey.user"`)
 	}
@@ -677,6 +696,9 @@ func (_u *APIKeyUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(apikey.FieldStatus, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.FastModePolicy(); ok {
+		_spec.SetField(apikey.FieldFastModePolicy, field.TypeString, value)
 	}
 	if value, ok := _u.mutation.LastUsedAt(); ok {
 		_spec.SetField(apikey.FieldLastUsedAt, field.TypeTime, value)
@@ -1023,6 +1045,20 @@ func (_u *APIKeyUpdateOne) SetStatus(v string) *APIKeyUpdateOne {
 func (_u *APIKeyUpdateOne) SetNillableStatus(v *string) *APIKeyUpdateOne {
 	if v != nil {
 		_u.SetStatus(*v)
+	}
+	return _u
+}
+
+// SetFastModePolicy sets the "fast_mode_policy" field.
+func (_u *APIKeyUpdateOne) SetFastModePolicy(v string) *APIKeyUpdateOne {
+	_u.mutation.SetFastModePolicy(v)
+	return _u
+}
+
+// SetNillableFastModePolicy sets the "fast_mode_policy" field if the given value is not nil.
+func (_u *APIKeyUpdateOne) SetNillableFastModePolicy(v *string) *APIKeyUpdateOne {
+	if v != nil {
+		_u.SetFastModePolicy(*v)
 	}
 	return _u
 }
@@ -1548,6 +1584,11 @@ func (_u *APIKeyUpdateOne) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "APIKey.status": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FastModePolicy(); ok {
+		if err := apikey.FastModePolicyValidator(v); err != nil {
+			return &ValidationError{Name: "fast_mode_policy", err: fmt.Errorf(`ent: validator failed for field "APIKey.fast_mode_policy": %w`, err)}
+		}
+	}
 	if _u.mutation.UserCleared() && len(_u.mutation.UserIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "APIKey.user"`)
 	}
@@ -1600,6 +1641,9 @@ func (_u *APIKeyUpdateOne) sqlSave(ctx context.Context) (_node *APIKey, err erro
 	}
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(apikey.FieldStatus, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.FastModePolicy(); ok {
+		_spec.SetField(apikey.FieldFastModePolicy, field.TypeString, value)
 	}
 	if value, ok := _u.mutation.LastUsedAt(); ok {
 		_spec.SetField(apikey.FieldLastUsedAt, field.TypeTime, value)

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -18,6 +18,7 @@ var (
 		{Name: "key", Type: field.TypeString, Unique: true, Size: 128},
 		{Name: "name", Type: field.TypeString, Size: 100},
 		{Name: "status", Type: field.TypeString, Size: 20, Default: "active"},
+		{Name: "fast_mode_policy", Type: field.TypeString, Size: 32, Default: "follow_request"},
 		{Name: "last_used_at", Type: field.TypeTime, Nullable: true},
 		{Name: "ip_whitelist", Type: field.TypeJSON, Nullable: true},
 		{Name: "ip_blacklist", Type: field.TypeJSON, Nullable: true},
@@ -48,13 +49,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "api_keys_groups_api_keys",
-				Columns:    []*schema.Column{APIKeysColumns[26]},
+				Columns:    []*schema.Column{APIKeysColumns[27]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "api_keys_users_api_keys",
-				Columns:    []*schema.Column{APIKeysColumns[27]},
+				Columns:    []*schema.Column{APIKeysColumns[28]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -63,12 +64,12 @@ var (
 			{
 				Name:    "apikey_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{APIKeysColumns[27]},
+				Columns: []*schema.Column{APIKeysColumns[28]},
 			},
 			{
 				Name:    "apikey_group_id",
 				Unique:  false,
-				Columns: []*schema.Column{APIKeysColumns[26]},
+				Columns: []*schema.Column{APIKeysColumns[27]},
 			},
 			{
 				Name:    "apikey_status",
@@ -83,22 +84,22 @@ var (
 			{
 				Name:    "apikey_last_used_at",
 				Unique:  false,
-				Columns: []*schema.Column{APIKeysColumns[7]},
+				Columns: []*schema.Column{APIKeysColumns[8]},
 			},
 			{
 				Name:    "apikey_quota_quota_used",
 				Unique:  false,
-				Columns: []*schema.Column{APIKeysColumns[10], APIKeysColumns[11]},
+				Columns: []*schema.Column{APIKeysColumns[11], APIKeysColumns[12]},
 			},
 			{
 				Name:    "apikey_expires_at",
 				Unique:  false,
-				Columns: []*schema.Column{APIKeysColumns[12]},
+				Columns: []*schema.Column{APIKeysColumns[13]},
 			},
 			{
 				Name:    "apikey_data_sharing_confirmed_group_id",
 				Unique:  false,
-				Columns: []*schema.Column{APIKeysColumns[23]},
+				Columns: []*schema.Column{APIKeysColumns[24]},
 			},
 		},
 	}

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -116,6 +116,7 @@ type APIKeyMutation struct {
 	key                                        *string
 	name                                       *string
 	status                                     *string
+	fast_mode_policy                           *string
 	last_used_at                               *time.Time
 	ip_whitelist                               *[]string
 	appendip_whitelist                         []string
@@ -570,6 +571,42 @@ func (m *APIKeyMutation) OldStatus(ctx context.Context) (v string, err error) {
 // ResetStatus resets all changes to the "status" field.
 func (m *APIKeyMutation) ResetStatus() {
 	m.status = nil
+}
+
+// SetFastModePolicy sets the "fast_mode_policy" field.
+func (m *APIKeyMutation) SetFastModePolicy(s string) {
+	m.fast_mode_policy = &s
+}
+
+// FastModePolicy returns the value of the "fast_mode_policy" field in the mutation.
+func (m *APIKeyMutation) FastModePolicy() (r string, exists bool) {
+	v := m.fast_mode_policy
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFastModePolicy returns the old "fast_mode_policy" field's value of the APIKey entity.
+// If the APIKey object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *APIKeyMutation) OldFastModePolicy(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFastModePolicy is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFastModePolicy requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFastModePolicy: %w", err)
+	}
+	return oldValue.FastModePolicy, nil
+}
+
+// ResetFastModePolicy resets all changes to the "fast_mode_policy" field.
+func (m *APIKeyMutation) ResetFastModePolicy() {
+	m.fast_mode_policy = nil
 }
 
 // SetLastUsedAt sets the "last_used_at" field.
@@ -1748,7 +1785,7 @@ func (m *APIKeyMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *APIKeyMutation) Fields() []string {
-	fields := make([]string, 0, 27)
+	fields := make([]string, 0, 28)
 	if m.created_at != nil {
 		fields = append(fields, apikey.FieldCreatedAt)
 	}
@@ -1772,6 +1809,9 @@ func (m *APIKeyMutation) Fields() []string {
 	}
 	if m.status != nil {
 		fields = append(fields, apikey.FieldStatus)
+	}
+	if m.fast_mode_policy != nil {
+		fields = append(fields, apikey.FieldFastModePolicy)
 	}
 	if m.last_used_at != nil {
 		fields = append(fields, apikey.FieldLastUsedAt)
@@ -1854,6 +1894,8 @@ func (m *APIKeyMutation) Field(name string) (ent.Value, bool) {
 		return m.GroupID()
 	case apikey.FieldStatus:
 		return m.Status()
+	case apikey.FieldFastModePolicy:
+		return m.FastModePolicy()
 	case apikey.FieldLastUsedAt:
 		return m.LastUsedAt()
 	case apikey.FieldIPWhitelist:
@@ -1917,6 +1959,8 @@ func (m *APIKeyMutation) OldField(ctx context.Context, name string) (ent.Value, 
 		return m.OldGroupID(ctx)
 	case apikey.FieldStatus:
 		return m.OldStatus(ctx)
+	case apikey.FieldFastModePolicy:
+		return m.OldFastModePolicy(ctx)
 	case apikey.FieldLastUsedAt:
 		return m.OldLastUsedAt(ctx)
 	case apikey.FieldIPWhitelist:
@@ -2019,6 +2063,13 @@ func (m *APIKeyMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetStatus(v)
+		return nil
+	case apikey.FieldFastModePolicy:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFastModePolicy(v)
 		return nil
 	case apikey.FieldLastUsedAt:
 		v, ok := value.(time.Time)
@@ -2417,6 +2468,9 @@ func (m *APIKeyMutation) ResetField(name string) error {
 		return nil
 	case apikey.FieldStatus:
 		m.ResetStatus()
+		return nil
+	case apikey.FieldFastModePolicy:
+		m.ResetFastModePolicy()
 		return nil
 	case apikey.FieldLastUsedAt:
 		m.ResetLastUsedAt()

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -112,44 +112,50 @@ func init() {
 	apikey.DefaultStatus = apikeyDescStatus.Default.(string)
 	// apikey.StatusValidator is a validator for the "status" field. It is called by the builders before save.
 	apikey.StatusValidator = apikeyDescStatus.Validators[0].(func(string) error)
+	// apikeyDescFastModePolicy is the schema descriptor for fast_mode_policy field.
+	apikeyDescFastModePolicy := apikeyFields[5].Descriptor()
+	// apikey.DefaultFastModePolicy holds the default value on creation for the fast_mode_policy field.
+	apikey.DefaultFastModePolicy = apikeyDescFastModePolicy.Default.(string)
+	// apikey.FastModePolicyValidator is a validator for the "fast_mode_policy" field. It is called by the builders before save.
+	apikey.FastModePolicyValidator = apikeyDescFastModePolicy.Validators[0].(func(string) error)
 	// apikeyDescQuota is the schema descriptor for quota field.
-	apikeyDescQuota := apikeyFields[8].Descriptor()
+	apikeyDescQuota := apikeyFields[9].Descriptor()
 	// apikey.DefaultQuota holds the default value on creation for the quota field.
 	apikey.DefaultQuota = apikeyDescQuota.Default.(float64)
 	// apikeyDescQuotaUsed is the schema descriptor for quota_used field.
-	apikeyDescQuotaUsed := apikeyFields[9].Descriptor()
+	apikeyDescQuotaUsed := apikeyFields[10].Descriptor()
 	// apikey.DefaultQuotaUsed holds the default value on creation for the quota_used field.
 	apikey.DefaultQuotaUsed = apikeyDescQuotaUsed.Default.(float64)
 	// apikeyDescRateLimit5h is the schema descriptor for rate_limit_5h field.
-	apikeyDescRateLimit5h := apikeyFields[11].Descriptor()
+	apikeyDescRateLimit5h := apikeyFields[12].Descriptor()
 	// apikey.DefaultRateLimit5h holds the default value on creation for the rate_limit_5h field.
 	apikey.DefaultRateLimit5h = apikeyDescRateLimit5h.Default.(float64)
 	// apikeyDescRateLimit1d is the schema descriptor for rate_limit_1d field.
-	apikeyDescRateLimit1d := apikeyFields[12].Descriptor()
+	apikeyDescRateLimit1d := apikeyFields[13].Descriptor()
 	// apikey.DefaultRateLimit1d holds the default value on creation for the rate_limit_1d field.
 	apikey.DefaultRateLimit1d = apikeyDescRateLimit1d.Default.(float64)
 	// apikeyDescRateLimit7d is the schema descriptor for rate_limit_7d field.
-	apikeyDescRateLimit7d := apikeyFields[13].Descriptor()
+	apikeyDescRateLimit7d := apikeyFields[14].Descriptor()
 	// apikey.DefaultRateLimit7d holds the default value on creation for the rate_limit_7d field.
 	apikey.DefaultRateLimit7d = apikeyDescRateLimit7d.Default.(float64)
 	// apikeyDescUsage5h is the schema descriptor for usage_5h field.
-	apikeyDescUsage5h := apikeyFields[14].Descriptor()
+	apikeyDescUsage5h := apikeyFields[15].Descriptor()
 	// apikey.DefaultUsage5h holds the default value on creation for the usage_5h field.
 	apikey.DefaultUsage5h = apikeyDescUsage5h.Default.(float64)
 	// apikeyDescUsage1d is the schema descriptor for usage_1d field.
-	apikeyDescUsage1d := apikeyFields[15].Descriptor()
+	apikeyDescUsage1d := apikeyFields[16].Descriptor()
 	// apikey.DefaultUsage1d holds the default value on creation for the usage_1d field.
 	apikey.DefaultUsage1d = apikeyDescUsage1d.Default.(float64)
 	// apikeyDescUsage7d is the schema descriptor for usage_7d field.
-	apikeyDescUsage7d := apikeyFields[16].Descriptor()
+	apikeyDescUsage7d := apikeyFields[17].Descriptor()
 	// apikey.DefaultUsage7d holds the default value on creation for the usage_7d field.
 	apikey.DefaultUsage7d = apikeyDescUsage7d.Default.(float64)
 	// apikeyDescDataSharingNoticeVersion is the schema descriptor for data_sharing_notice_version field.
-	apikeyDescDataSharingNoticeVersion := apikeyFields[20].Descriptor()
+	apikeyDescDataSharingNoticeVersion := apikeyFields[21].Descriptor()
 	// apikey.DefaultDataSharingNoticeVersion holds the default value on creation for the data_sharing_notice_version field.
 	apikey.DefaultDataSharingNoticeVersion = apikeyDescDataSharingNoticeVersion.Default.(int)
 	// apikeyDescFallbackToDefaultGroupWhenUnavailable is the schema descriptor for fallback_to_default_group_when_unavailable field.
-	apikeyDescFallbackToDefaultGroupWhenUnavailable := apikeyFields[23].Descriptor()
+	apikeyDescFallbackToDefaultGroupWhenUnavailable := apikeyFields[24].Descriptor()
 	// apikey.DefaultFallbackToDefaultGroupWhenUnavailable holds the default value on creation for the fallback_to_default_group_when_unavailable field.
 	apikey.DefaultFallbackToDefaultGroupWhenUnavailable = apikeyDescFallbackToDefaultGroupWhenUnavailable.Default.(bool)
 	accountMixin := schema.Account{}.Mixin()

--- a/backend/ent/schema/api_key.go
+++ b/backend/ent/schema/api_key.go
@@ -47,6 +47,11 @@ func (APIKey) Fields() []ent.Field {
 		field.String("status").
 			MaxLen(20).
 			Default(domain.StatusActive),
+		// 单个 API Key 的 Fast 模式策略，默认保持下游请求的现有行为。
+		field.String("fast_mode_policy").
+			MaxLen(32).
+			Default("follow_request").
+			Comment("API Key 的 Fast 模式策略：follow_request、force_on 或 force_off"),
 		field.Time("last_used_at").
 			Optional().
 			Nillable().

--- a/backend/internal/handler/api_key_handler.go
+++ b/backend/internal/handler/api_key_handler.go
@@ -36,13 +36,14 @@ func (h *APIKeyHandler) SetGroupCapacityService(groupCapacityService *service.Gr
 
 // CreateAPIKeyRequest represents the create API key request payload
 type CreateAPIKeyRequest struct {
-	Name          string   `json:"name" binding:"required"`
-	GroupID       *int64   `json:"group_id"`        // nullable
-	CustomKey     *string  `json:"custom_key"`      // 可选的自定义key
-	IPWhitelist   []string `json:"ip_whitelist"`    // IP 白名单
-	IPBlacklist   []string `json:"ip_blacklist"`    // IP 黑名单
-	Quota         *float64 `json:"quota"`           // 配额限制 (USD)
-	ExpiresInDays *int     `json:"expires_in_days"` // 过期天数
+	Name           string   `json:"name" binding:"required"`
+	GroupID        *int64   `json:"group_id"`         // nullable
+	CustomKey      *string  `json:"custom_key"`       // 可选的自定义key
+	IPWhitelist    []string `json:"ip_whitelist"`     // IP 白名单
+	IPBlacklist    []string `json:"ip_blacklist"`     // IP 黑名单
+	FastModePolicy string   `json:"fast_mode_policy"` // Fast 模式策略，空值表示跟随请求
+	Quota          *float64 `json:"quota"`            // 配额限制 (USD)
+	ExpiresInDays  *int     `json:"expires_in_days"`  // 过期天数
 
 	// Rate limit fields (0 = unlimited)
 	RateLimit5h *float64 `json:"rate_limit_5h"`
@@ -57,14 +58,15 @@ type CreateAPIKeyRequest struct {
 
 // UpdateAPIKeyRequest represents the update API key request payload
 type UpdateAPIKeyRequest struct {
-	Name        string   `json:"name"`
-	GroupID     *int64   `json:"group_id"`
-	Status      string   `json:"status" binding:"omitempty,oneof=active inactive"`
-	IPWhitelist []string `json:"ip_whitelist"` // IP 白名单
-	IPBlacklist []string `json:"ip_blacklist"` // IP 黑名单
-	Quota       *float64 `json:"quota"`        // 配额限制 (USD), 0=无限制
-	ExpiresAt   *string  `json:"expires_at"`   // 过期时间 (ISO 8601)
-	ResetQuota  *bool    `json:"reset_quota"`  // 重置已用配额
+	Name           string   `json:"name"`
+	GroupID        *int64   `json:"group_id"`
+	Status         string   `json:"status" binding:"omitempty,oneof=active inactive"`
+	IPWhitelist    []string `json:"ip_whitelist"`     // IP 白名单
+	IPBlacklist    []string `json:"ip_blacklist"`     // IP 黑名单
+	FastModePolicy *string  `json:"fast_mode_policy"` // nil 表示保持原配置
+	Quota          *float64 `json:"quota"`            // 配额限制 (USD), 0=无限制
+	ExpiresAt      *string  `json:"expires_at"`       // 过期时间 (ISO 8601)
+	ResetQuota     *bool    `json:"reset_quota"`      // 重置已用配额
 
 	// Rate limit fields (nil = no change, 0 = unlimited)
 	RateLimit5h         *float64 `json:"rate_limit_5h"`
@@ -175,6 +177,7 @@ func (h *APIKeyHandler) Create(c *gin.Context) {
 		CustomKey:                             req.CustomKey,
 		IPWhitelist:                           req.IPWhitelist,
 		IPBlacklist:                           req.IPBlacklist,
+		FastModePolicy:                        req.FastModePolicy,
 		ExpiresInDays:                         req.ExpiresInDays,
 		FallbackToDefaultGroupWhenUnavailable: req.FallbackToDefaultGroupWhenUnavailable,
 		DataSharingConfirmed:                  req.DataSharingConfirmed,
@@ -226,6 +229,7 @@ func (h *APIKeyHandler) Update(c *gin.Context) {
 	svcReq := service.UpdateAPIKeyRequest{
 		IPWhitelist:                           req.IPWhitelist,
 		IPBlacklist:                           req.IPBlacklist,
+		FastModePolicy:                        req.FastModePolicy,
 		Quota:                                 req.Quota,
 		ResetQuota:                            req.ResetQuota,
 		RateLimit5h:                           req.RateLimit5h,

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -88,6 +88,7 @@ func APIKeyFromService(k *service.APIKey) *APIKey {
 		Name:                                  k.Name,
 		GroupID:                               k.GroupID,
 		Status:                                k.Status,
+		FastModePolicy:                        k.FastModePolicy,
 		IPWhitelist:                           k.IPWhitelist,
 		IPBlacklist:                           k.IPBlacklist,
 		LastUsedAt:                            k.LastUsedAt,

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -52,21 +52,22 @@ type AdminUser struct {
 }
 
 type APIKey struct {
-	ID          int64      `json:"id"`
-	UserID      int64      `json:"user_id"`
-	Key         string     `json:"key"`
-	Name        string     `json:"name"`
-	GroupID     *int64     `json:"group_id"`
-	Status      string     `json:"status"`
-	IPWhitelist []string   `json:"ip_whitelist"`
-	IPBlacklist []string   `json:"ip_blacklist"`
-	LastUsedAt  *time.Time `json:"last_used_at"`
-	LastUsedIP  *string    `json:"last_used_ip"` // 最近一条带 IP 的用量日志。
-	Quota       float64    `json:"quota"`        // Quota limit in USD (0 = unlimited)
-	QuotaUsed   float64    `json:"quota_used"`   // Used quota amount in USD
-	ExpiresAt   *time.Time `json:"expires_at"`   // Expiration time (nil = never expires)
-	CreatedAt   time.Time  `json:"created_at"`
-	UpdatedAt   time.Time  `json:"updated_at"`
+	ID             int64      `json:"id"`
+	UserID         int64      `json:"user_id"`
+	Key            string     `json:"key"`
+	Name           string     `json:"name"`
+	GroupID        *int64     `json:"group_id"`
+	Status         string     `json:"status"`
+	FastModePolicy string     `json:"fast_mode_policy"`
+	IPWhitelist    []string   `json:"ip_whitelist"`
+	IPBlacklist    []string   `json:"ip_blacklist"`
+	LastUsedAt     *time.Time `json:"last_used_at"`
+	LastUsedIP     *string    `json:"last_used_ip"` // 最近一条带 IP 的用量日志。
+	Quota          float64    `json:"quota"`        // Quota limit in USD (0 = unlimited)
+	QuotaUsed      float64    `json:"quota_used"`   // Used quota amount in USD
+	ExpiresAt      *time.Time `json:"expires_at"`   // Expiration time (nil = never expires)
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
 	// 数据共享确认记录，用于前端判断切换分组时是否需要重新弹窗。
 	DataSharingNoticeVersion    int        `json:"data_sharing_notice_version"`
 	DataSharingConfirmedGroupID *int64     `json:"data_sharing_confirmed_group_id"`

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -267,6 +267,12 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		}
 
 		if err != nil {
+			var betaBlockedErr *service.BetaBlockedError
+			if errors.As(err, &betaBlockedErr) {
+				service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalPolicyDenied)
+				h.chatCompletionsErrorResponse(c, http.StatusBadRequest, "invalid_request_error", betaBlockedErr.Message)
+				return
+			}
 			var failoverErr *service.UpstreamFailoverError
 			if errors.As(err, &failoverErr) {
 				if c.Writer.Size() != writerSizeBeforeForward {

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -244,6 +244,12 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		}
 
 		if err != nil {
+			var betaBlockedErr *service.BetaBlockedError
+			if errors.As(err, &betaBlockedErr) {
+				service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalPolicyDenied)
+				h.responsesErrorResponse(c, http.StatusBadRequest, "invalid_request_error", betaBlockedErr.Message)
+				return
+			}
 			var failoverErr *service.UpstreamFailoverError
 			if errors.As(err, &failoverErr) {
 				// Can't failover if streaming content already sent

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -28,6 +28,10 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 		Stream:  req.Stream,
 		Include: []string{"reasoning.encrypted_content"},
 	}
+	// Claude Fast 转为 OpenAI 请求级 Priority；系统策略会在上游发送前最终裁决。
+	if strings.EqualFold(strings.TrimSpace(req.Speed), "fast") {
+		out.ServiceTier = "priority"
+	}
 
 	// Responses API 的 gpt-5.x 推理模型不接受采样参数，携带 temperature/top_p 会触发 400。
 	// 因此只有非推理模型才透传这些参数。

--- a/backend/internal/pkg/apicompat/fast_mode_conversion_test.go
+++ b/backend/internal/pkg/apicompat/fast_mode_conversion_test.go
@@ -1,0 +1,33 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnthropicFastConvertsToOpenAIPriority(t *testing.T) {
+	content, err := json.Marshal("hello")
+	require.NoError(t, err)
+	converted, err := AnthropicToResponses(&AnthropicRequest{
+		Model:     "claude-opus-4.8",
+		MaxTokens: 128,
+		Speed:     "fast",
+		Messages:  []AnthropicMessage{{Role: "user", Content: content}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "priority", converted.ServiceTier)
+}
+
+func TestOpenAIPriorityConvertsToClaudeFast(t *testing.T) {
+	input, err := json.Marshal("hello")
+	require.NoError(t, err)
+	converted, err := ResponsesToAnthropicRequest(&ResponsesRequest{
+		Model:       "claude-opus-4.8",
+		Input:       input,
+		ServiceTier: "priority",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "fast", converted.Speed)
+}

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -23,6 +23,11 @@ func ResponsesToAnthropicRequest(req *ResponsesRequest) (*AnthropicRequest, erro
 		TopP:        req.TopP,
 		Stream:      req.Stream,
 	}
+	// OpenAI Priority/Fast 转为 Claude Fast 候选，beta header 由网关统一补齐。
+	switch strings.ToLower(strings.TrimSpace(req.ServiceTier)) {
+	case "priority", "fast":
+		out.Speed = "fast"
+	}
 
 	if len(system) > 0 {
 		out.System = system

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -15,12 +15,14 @@ import (
 
 // AnthropicRequest is the request body for POST /v1/messages.
 type AnthropicRequest struct {
-	Model       string             `json:"model"`
-	MaxTokens   int                `json:"max_tokens"`
-	System      json.RawMessage    `json:"system,omitempty"` // string or []AnthropicContentBlock
-	Messages    []AnthropicMessage `json:"messages"`
-	Tools       []AnthropicTool    `json:"tools,omitempty"`
-	Stream      bool               `json:"stream,omitempty"`
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	System    json.RawMessage    `json:"system,omitempty"` // string or []AnthropicContentBlock
+	Messages  []AnthropicMessage `json:"messages"`
+	Tools     []AnthropicTool    `json:"tools,omitempty"`
+	Stream    bool               `json:"stream,omitempty"`
+	// Speed 为 Claude Fast 模式字段，目前支持 "fast"。
+	Speed       string             `json:"speed,omitempty"`
 	Temperature *float64           `json:"temperature,omitempty"`
 	TopP        *float64           `json:"top_p,omitempty"`
 	StopSeqs    []string           `json:"stop_sequences,omitempty"`
@@ -145,6 +147,8 @@ type AnthropicUsage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	// Speed 为 Claude 实际处理速度：fast 或 standard。
+	Speed string `json:"speed,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/pkg/ctxkey/ctxkey.go
+++ b/backend/internal/pkg/ctxkey/ctxkey.go
@@ -49,6 +49,9 @@ const (
 	// 供 service 层执行用户级策略，不能使用客户端请求体中的 user 标识替代。
 	UserID Key = "ctx_user_id"
 
+	// APIKeyFastModePolicy 为鉴权后的单 Key Fast 模式策略，不能信任客户端同名字段。
+	APIKeyFastModePolicy Key = "ctx_api_key_fast_mode_policy"
+
 	// IsMaxTokensOneHaikuRequest 标识当前请求是否为 max_tokens=1 + haiku 模型的探测请求
 	// 用于 ClaudeCodeOnly 验证绕过（绕过 system prompt 检查，但仍需验证 User-Agent）
 	IsMaxTokensOneHaikuRequest Key = "ctx_is_max_tokens_one_haiku"

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -41,12 +41,22 @@ func (r *apiKeyRepository) activeQuery() *dbent.APIKeyQuery {
 	return r.client.APIKey.Query().Where(apikey.DeletedAtIsNil())
 }
 
+// apiKeyFastModePolicyForPersistence 兼容绕过服务层的旧夹具和内部调用。
+func apiKeyFastModePolicyForPersistence(value string) string {
+	policy, ok := service.NormalizeAPIKeyFastModePolicy(value)
+	if ok {
+		return policy
+	}
+	return value
+}
+
 func (r *apiKeyRepository) Create(ctx context.Context, key *service.APIKey) error {
 	builder := r.client.APIKey.Create().
 		SetUserID(key.UserID).
 		SetKey(key.Key).
 		SetName(key.Name).
 		SetStatus(key.Status).
+		SetFastModePolicy(apiKeyFastModePolicyForPersistence(key.FastModePolicy)).
 		SetNillableGroupID(key.GroupID).
 		SetNillableLastUsedAt(key.LastUsedAt).
 		SetQuota(key.Quota).
@@ -140,6 +150,7 @@ func (r *apiKeyRepository) GetByKeyForAuth(ctx context.Context, key string) (*se
 			apikey.FieldGroupID,
 			apikey.FieldName,
 			apikey.FieldStatus,
+			apikey.FieldFastModePolicy,
 			apikey.FieldIPWhitelist,
 			apikey.FieldIPBlacklist,
 			apikey.FieldQuota,
@@ -237,6 +248,7 @@ func (r *apiKeyRepository) Update(ctx context.Context, key *service.APIKey) erro
 		Where(apikey.IDEQ(key.ID), apikey.DeletedAtIsNil()).
 		SetName(key.Name).
 		SetStatus(key.Status).
+		SetFastModePolicy(apiKeyFastModePolicyForPersistence(key.FastModePolicy)).
 		SetQuota(key.Quota).
 		SetQuotaUsed(key.QuotaUsed).
 		SetRateLimit5h(key.RateLimit5h).
@@ -955,6 +967,7 @@ func apiKeyEntityToService(m *dbent.APIKey) *service.APIKey {
 		Key:                                   m.Key,
 		Name:                                  m.Name,
 		Status:                                m.Status,
+		FastModePolicy:                        m.FastModePolicy,
 		IPWhitelist:                           m.IPWhitelist,
 		IPBlacklist:                           m.IPBlacklist,
 		LastUsedAt:                            m.LastUsedAt,

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -232,6 +232,7 @@ func TestAPIContracts(t *testing.T) {
 					"name": "Key One",
 					"group_id": null,
 					"status": "active",
+					"fast_mode_policy": "follow_request",
 					"ip_whitelist": null,
 					"ip_blacklist": null,
 					"last_used_at": null,
@@ -288,6 +289,7 @@ func TestAPIContracts(t *testing.T) {
 							"name": "Key One",
 							"group_id": null,
 							"status": "active",
+							"fast_mode_policy": "follow_request",
 							"ip_whitelist": null,
 							"ip_blacklist": null,
 							"last_used_at": null,
@@ -2460,6 +2462,10 @@ func (r *stubApiKeyRepo) MustSeed(key *service.APIKey) {
 		return
 	}
 	clone := *key
+	// 合约夹具与数据库默认值保持一致，避免返回生产环境不存在的空策略。
+	if clone.FastModePolicy == "" {
+		clone.FastModePolicy = service.APIKeyFastModePolicyFollowRequest
+	}
 	r.byID[clone.ID] = &clone
 	r.byKey[clone.Key] = &clone
 }

--- a/backend/internal/server/middleware/api_key_auth.go
+++ b/backend/internal/server/middleware/api_key_auth.go
@@ -132,6 +132,7 @@ func apiKeyAuthWithSubscription(apiKeyService *service.APIKeyService, subscripti
 			return
 		}
 		ctx := context.WithValue(c.Request.Context(), ctxkey.UserID, apiKey.User.ID)
+		ctx = context.WithValue(ctx, ctxkey.APIKeyFastModePolicy, apiKey.FastModePolicy)
 		c.Request = c.Request.WithContext(ctx)
 
 		// ── 4. SimpleMode → early return ─────────────────────────────

--- a/backend/internal/server/middleware/api_key_auth_test.go
+++ b/backend/internal/server/middleware/api_key_auth_test.go
@@ -257,12 +257,13 @@ func TestAPIKeyAuthSetsGroupContext(t *testing.T) {
 		Concurrency: 3,
 	}
 	apiKey := &service.APIKey{
-		ID:     100,
-		UserID: user.ID,
-		Key:    "test-key",
-		Status: service.StatusActive,
-		User:   user,
-		Group:  group,
+		ID:             100,
+		UserID:         user.ID,
+		Key:            "test-key",
+		Status:         service.StatusActive,
+		FastModePolicy: service.APIKeyFastModePolicyForceOff,
+		User:           user,
+		Group:          group,
 	}
 	apiKey.GroupID = &group.ID
 
@@ -288,6 +289,11 @@ func TestAPIKeyAuthSetsGroupContext(t *testing.T) {
 		}
 		userIDFromCtx, ok := c.Request.Context().Value(ctxkey.UserID).(int64)
 		if !ok || userIDFromCtx != user.ID {
+			c.JSON(http.StatusInternalServerError, gin.H{"ok": false})
+			return
+		}
+		fastModePolicy, ok := c.Request.Context().Value(ctxkey.APIKeyFastModePolicy).(string)
+		if !ok || fastModePolicy != service.APIKeyFastModePolicyForceOff {
 			c.JSON(http.StatusInternalServerError, gin.H{"ok": false})
 			return
 		}

--- a/backend/internal/service/api_key.go
+++ b/backend/internal/service/api_key.go
@@ -14,6 +14,26 @@ const (
 	StatusAPIKeyExpired        = "expired"
 )
 
+// API Key Fast 模式策略常量。
+const (
+	APIKeyFastModePolicyFollowRequest = "follow_request"
+	APIKeyFastModePolicyForceOn       = "force_on"
+	APIKeyFastModePolicyForceOff      = "force_off"
+)
+
+// NormalizeAPIKeyFastModePolicy 校验并规范化 API Key Fast 模式策略。
+// 空值用于兼容旧客户端，按跟随下游请求处理。
+func NormalizeAPIKeyFastModePolicy(value string) (string, bool) {
+	switch value {
+	case "", APIKeyFastModePolicyFollowRequest:
+		return APIKeyFastModePolicyFollowRequest, true
+	case APIKeyFastModePolicyForceOn, APIKeyFastModePolicyForceOff:
+		return value, true
+	default:
+		return "", false
+	}
+}
+
 // Rate limit window durations
 const (
 	RateLimitWindow5h = 5 * time.Hour
@@ -28,14 +48,16 @@ func IsWindowExpired(windowStart *time.Time, duration time.Duration) bool {
 }
 
 type APIKey struct {
-	ID          int64
-	UserID      int64
-	Key         string
-	Name        string
-	GroupID     *int64
-	Status      string
-	IPWhitelist []string
-	IPBlacklist []string
+	ID      int64
+	UserID  int64
+	Key     string
+	Name    string
+	GroupID *int64
+	Status  string
+	// FastModePolicy 控制该 Key 的请求级 Fast 模式，系统策略仍拥有更高优先级。
+	FastModePolicy string
+	IPWhitelist    []string
+	IPBlacklist    []string
 	// 预编译的 IP 规则，用于认证热路径避免重复 ParseIP/ParseCIDR。
 	CompiledIPWhitelist *ip.CompiledIPRules `json:"-"`
 	CompiledIPBlacklist *ip.CompiledIPRules `json:"-"`

--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -4,16 +4,18 @@ import "time"
 
 // APIKeyAuthSnapshot API Key 认证缓存快照（仅包含认证所需字段）
 type APIKeyAuthSnapshot struct {
-	Version     int                      `json:"version"`
-	APIKeyID    int64                    `json:"api_key_id"`
-	UserID      int64                    `json:"user_id"`
-	GroupID     *int64                   `json:"group_id,omitempty"`
-	Name        string                   `json:"name"`
-	Status      string                   `json:"status"`
-	IPWhitelist []string                 `json:"ip_whitelist,omitempty"`
-	IPBlacklist []string                 `json:"ip_blacklist,omitempty"`
-	User        APIKeyAuthUserSnapshot   `json:"user"`
-	Group       *APIKeyAuthGroupSnapshot `json:"group,omitempty"`
+	Version  int    `json:"version"`
+	APIKeyID int64  `json:"api_key_id"`
+	UserID   int64  `json:"user_id"`
+	GroupID  *int64 `json:"group_id,omitempty"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	// FastModePolicy 随鉴权快照下发，供网关热路径读取。
+	FastModePolicy string                   `json:"fast_mode_policy"`
+	IPWhitelist    []string                 `json:"ip_whitelist,omitempty"`
+	IPBlacklist    []string                 `json:"ip_blacklist,omitempty"`
+	User           APIKeyAuthUserSnapshot   `json:"user"`
+	Group          *APIKeyAuthGroupSnapshot `json:"group,omitempty"`
 
 	// Quota fields for API Key independent quota feature
 	Quota     float64 `json:"quota"`      // Quota limit in USD (0 = unlimited)

--- a/backend/internal/service/api_key_auth_cache_impl.go
+++ b/backend/internal/service/api_key_auth_cache_impl.go
@@ -14,7 +14,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 )
 
-const apiKeyAuthSnapshotVersion = 20 // v20：认证快照包含分组网页搜索按次计费字段
+const apiKeyAuthSnapshotVersion = 21 // v21：认证快照包含 API Key Fast 模式策略
 
 type apiKeyAuthCacheConfig struct {
 	l1Size        int
@@ -212,6 +212,7 @@ func (s *APIKeyService) snapshotFromAPIKey(ctx context.Context, apiKey *APIKey) 
 		GroupID:                               apiKey.GroupID,
 		Name:                                  apiKey.Name,
 		Status:                                apiKey.Status,
+		FastModePolicy:                        apiKey.FastModePolicy,
 		IPWhitelist:                           apiKey.IPWhitelist,
 		IPBlacklist:                           apiKey.IPBlacklist,
 		Quota:                                 apiKey.Quota,
@@ -304,6 +305,7 @@ func (s *APIKeyService) snapshotToAPIKey(key string, snapshot *APIKeyAuthSnapsho
 		Key:                                   key,
 		Name:                                  snapshot.Name,
 		Status:                                snapshot.Status,
+		FastModePolicy:                        snapshot.FastModePolicy,
 		IPWhitelist:                           snapshot.IPWhitelist,
 		IPBlacklist:                           snapshot.IPBlacklist,
 		Quota:                                 snapshot.Quota,

--- a/backend/internal/service/api_key_fast_mode.go
+++ b/backend/internal/service/api_key_fast_mode.go
@@ -1,0 +1,132 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/TokenFlux/TokenRouter/internal/pkg/claude"
+	"github.com/TokenFlux/TokenRouter/internal/pkg/ctxkey"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// apiKeyFastModePolicyFromContext 只读取鉴权中间件写入的可信策略。
+func apiKeyFastModePolicyFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return APIKeyFastModePolicyFollowRequest
+	}
+	raw, _ := ctx.Value(ctxkey.APIKeyFastModePolicy).(string)
+	policy, ok := NormalizeAPIKeyFastModePolicy(strings.TrimSpace(raw))
+	if !ok {
+		return APIKeyFastModePolicyFollowRequest
+	}
+	return policy
+}
+
+// apiKeyFastModePricingModel 优先使用入口记录的用户可见模型，确保能力判断与分组定价一致。
+func apiKeyFastModePricingModel(ctx context.Context, fallback string) string {
+	if ctx != nil {
+		if model, ok := ctx.Value(ctxkey.Model).(string); ok && strings.TrimSpace(model) != "" {
+			return strings.TrimSpace(model)
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+// apiKeyFastModeSupported 按当前有效分组和模型定价判断 Fast 能力。
+// 缺少分组、解析器或定价结果时按不支持处理，避免 Key 配置误改上游请求。
+func apiKeyFastModeSupported(ctx context.Context, resolver *ModelPricingResolver, model string) bool {
+	if ctx == nil || resolver == nil || resolver.billingService == nil {
+		return false
+	}
+	group, ok := ctx.Value(ctxkey.Group).(*Group)
+	if !ok || group == nil || group.ID <= 0 {
+		return false
+	}
+	groupID := group.ID
+	resolved := resolver.Resolve(ctx, PricingInput{
+		Model:   apiKeyFastModePricingModel(ctx, model),
+		GroupID: &groupID,
+	})
+	return resolved != nil && resolved.SupportsServiceTier
+}
+
+// openAIAPIKeyFastModeSupported 将单 Key 策略限制到 OpenAI 原生适配器。
+func (s *OpenAIGatewayService) openAIAPIKeyFastModeSupported(ctx context.Context, account *Account, model string) bool {
+	return account != nil && account.IsOpenAI() && apiKeyFastModeSupported(ctx, s.resolver, model)
+}
+
+// claudeAPIKeyFastModeSupported 将 Claude Fast 限制到 Anthropic API Key 直连适配器。
+// Bedrock、Vertex 和 OAuth/Setup Token 路径不会应用单 Key Fast 策略。
+func (s *GatewayService) claudeAPIKeyFastModeSupported(ctx context.Context, account *Account, model string) bool {
+	return account != nil && account.IsAnthropic() && account.Type == AccountTypeAPIKey &&
+		apiKeyFastModeSupported(ctx, s.resolver, model)
+}
+
+// addAnthropicBetaToken 在保留其它 beta 的同时补齐指定 token。
+func addAnthropicBetaToken(header, token string) string {
+	if containsBetaToken(header, token) {
+		return header
+	}
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return token
+	}
+	return header + "," + token
+}
+
+// applyClaudeAPIKeyFastMode 将单 Key 策略编码为 Claude 官方 Fast wire 格式。
+// 这里只改写候选请求，最终 beta filter/block 仍由系统策略执行。
+func (s *GatewayService) applyClaudeAPIKeyFastMode(
+	ctx context.Context,
+	account *Account,
+	model string,
+	body []byte,
+	headers http.Header,
+) ([]byte, http.Header, error) {
+	if !s.claudeAPIKeyFastModeSupported(ctx, account, model) {
+		return body, headers, nil
+	}
+	if headers == nil {
+		headers = make(http.Header)
+	}
+
+	policy := apiKeyFastModePolicyFromContext(ctx)
+	fastRequested := strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, "speed").String()), "fast") ||
+		containsBetaToken(getHeaderRaw(headers, "anthropic-beta"), claude.BetaFastMode)
+	shouldFast := fastRequested
+	switch policy {
+	case APIKeyFastModePolicyForceOn:
+		shouldFast = true
+	case APIKeyFastModePolicyForceOff:
+		shouldFast = false
+	}
+
+	if shouldFast {
+		updated, err := sjson.SetBytes(body, "speed", "fast")
+		if err != nil {
+			return body, headers, fmt.Errorf("set Claude fast speed: %w", err)
+		}
+		cloned := headers.Clone()
+		setHeaderRaw(cloned, "anthropic-beta", addAnthropicBetaToken(getHeaderRaw(cloned, "anthropic-beta"), claude.BetaFastMode))
+		return updated, cloned, nil
+	}
+
+	if policy != APIKeyFastModePolicyForceOff {
+		return body, headers, nil
+	}
+	updated := body
+	if strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, "speed").String()), "fast") {
+		var err error
+		updated, err = sjson.DeleteBytes(body, "speed")
+		if err != nil {
+			return body, headers, fmt.Errorf("remove Claude fast speed: %w", err)
+		}
+	}
+	cloned := headers.Clone()
+	fastOnly := map[string]struct{}{claude.BetaFastMode: {}}
+	setHeaderRaw(cloned, "anthropic-beta", stripBetaTokensWithSet(getHeaderRaw(cloned, "anthropic-beta"), fastOnly))
+	return updated, cloned, nil
+}

--- a/backend/internal/service/api_key_fast_mode_test.go
+++ b/backend/internal/service/api_key_fast_mode_test.go
@@ -1,0 +1,197 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TokenFlux/TokenRouter/internal/config"
+	"github.com/TokenFlux/TokenRouter/internal/pkg/claude"
+	"github.com/TokenFlux/TokenRouter/internal/pkg/ctxkey"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func fastModeTestContext(policy, model string) context.Context {
+	ctx := context.WithValue(context.Background(), ctxkey.APIKeyFastModePolicy, policy)
+	ctx = context.WithValue(ctx, ctxkey.Group, &Group{ID: 11, Platform: PlatformOpenAI})
+	return context.WithValue(ctx, ctxkey.Model, model)
+}
+
+func fastModeTestResolver() *ModelPricingResolver {
+	pricing := &PricingService{pricingData: map[string]*LiteLLMModelPricing{
+		"gpt-5.5": {
+			InputCostPerToken:     5e-6,
+			OutputCostPerToken:    30e-6,
+			SupportsServiceTier:   true,
+			SupportsPromptCaching: true,
+		},
+		"claude-opus-4.8": {
+			InputCostPerToken:     5e-6,
+			OutputCostPerToken:    25e-6,
+			SupportsServiceTier:   true,
+			SupportsPromptCaching: true,
+		},
+	}}
+	billing := NewBillingService(&config.Config{}, pricing)
+	return NewModelPricingResolver(nil, billing)
+}
+
+func TestOpenAIAPIKeyFastModeForceOnAndOff(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithSettings(t, DefaultOpenAIFastPolicySettings())
+	svc.resolver = fastModeTestResolver()
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	forceOnCtx := fastModeTestContext(APIKeyFastModePolicyForceOn, "gpt-5.5")
+	updated, err := svc.applyOpenAIFastPolicyToBody(forceOnCtx, account, "gpt-5.5", []byte(`{"model":"gpt-5.5"}`))
+	require.NoError(t, err)
+	require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(updated, "service_tier").String())
+
+	forceOffCtx := fastModeTestContext(APIKeyFastModePolicyForceOff, "gpt-5.5")
+	updated, err = svc.applyOpenAIFastPolicyToBody(forceOffCtx, account, "gpt-5.5", []byte(`{"model":"gpt-5.5","service_tier":"priority"}`))
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(updated, "service_tier").Exists())
+}
+
+func TestOpenAIAPIKeyFastModeIgnoresUnsupportedModel(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithSettings(t, DefaultOpenAIFastPolicySettings())
+	svc.resolver = fastModeTestResolver()
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	ctx := fastModeTestContext(APIKeyFastModePolicyForceOn, "unknown-provider-model")
+
+	updated, err := svc.applyOpenAIFastPolicyToBody(ctx, account, "unknown-provider-model", []byte(`{"model":"unknown-provider-model"}`))
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(updated, "service_tier").Exists())
+}
+
+func TestOpenAIAPIKeyFastModeCannotBypassSystemPolicy(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithSettings(t, openAIFastFilterPriorityPolicy())
+	svc.resolver = fastModeTestResolver()
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	ctx := fastModeTestContext(APIKeyFastModePolicyForceOn, "gpt-5.5")
+
+	updated, err := svc.applyOpenAIFastPolicyToBody(ctx, account, "gpt-5.5", []byte(`{"model":"gpt-5.5"}`))
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(updated, "service_tier").Exists())
+
+	blockSvc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{Rules: []OpenAIFastPolicyRule{{
+		ServiceTier: OpenAIFastTierPriority,
+		Action:      BetaPolicyActionBlock,
+		Scope:       BetaPolicyScopeAll,
+	}}})
+	blockSvc.resolver = fastModeTestResolver()
+	_, err = blockSvc.applyOpenAIFastPolicyToBody(ctx, account, "gpt-5.5", []byte(`{"model":"gpt-5.5"}`))
+	var blocked *OpenAIFastBlockedError
+	require.ErrorAs(t, err, &blocked)
+
+	// 系统强制 priority 命中原始 flex 后，单 Key force_off 不能删除它。
+	svc = newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{Rules: []OpenAIFastPolicyRule{{
+		ServiceTier: OpenAIFastTierFlex,
+		Action:      OpenAIFastPolicyActionForcePriority,
+		Scope:       BetaPolicyScopeAll,
+	}}})
+	svc.resolver = fastModeTestResolver()
+	ctx = fastModeTestContext(APIKeyFastModePolicyForceOff, "gpt-5.5")
+	updated, err = svc.applyOpenAIFastPolicyToBody(ctx, account, "gpt-5.5", []byte(`{"model":"gpt-5.5","service_tier":"flex"}`))
+	require.NoError(t, err)
+	require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(updated, "service_tier").String())
+}
+
+func TestOpenAIAPIKeyFastModeAppliesToRealtimeFrames(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithSettings(t, DefaultOpenAIFastPolicySettings())
+	svc.resolver = fastModeTestResolver()
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	forceOnCtx := fastModeTestContext(APIKeyFastModePolicyForceOn, "gpt-5.5")
+	updated, blocked, err := svc.applyOpenAIFastPolicyToWSResponseCreate(forceOnCtx, account, "gpt-5.5", []byte(`{"type":"response.create","model":"gpt-5.5"}`))
+	require.NoError(t, err)
+	require.Nil(t, blocked)
+	require.Equal(t, OpenAIFastTierPriority, gjson.GetBytes(updated, "service_tier").String())
+
+	forceOffCtx := fastModeTestContext(APIKeyFastModePolicyForceOff, "gpt-5.5")
+	updated, blocked, err = svc.applyOpenAIFastPolicyToWSResponseCreate(forceOffCtx, account, "gpt-5.5", []byte(`{"type":"response.create","model":"gpt-5.5","service_tier":"priority"}`))
+	require.NoError(t, err)
+	require.Nil(t, blocked)
+	require.False(t, gjson.GetBytes(updated, "service_tier").Exists())
+}
+
+func TestAPIKeyFastModeIgnoresUnsupportedProviderAdapters(t *testing.T) {
+	openAISvc := newOpenAIGatewayServiceWithSettings(t, DefaultOpenAIFastPolicySettings())
+	openAISvc.resolver = fastModeTestResolver()
+	ctx := fastModeTestContext(APIKeyFastModePolicyForceOn, "gpt-5.5")
+	body, err := openAISvc.applyOpenAIFastPolicyToBody(ctx, &Account{Platform: PlatformGrok, Type: AccountTypeAPIKey}, "gpt-5.5", []byte(`{"model":"gpt-5.5"}`))
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(body, "service_tier").Exists())
+
+	claudeSvc := &GatewayService{resolver: fastModeTestResolver()}
+	body, headers, err := claudeSvc.applyClaudeAPIKeyFastMode(ctx, &Account{Platform: PlatformAnthropic, Type: AccountTypeBedrock}, "claude-opus-4.8", []byte(`{"model":"claude-opus-4.8"}`), http.Header{})
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(body, "speed").Exists())
+	require.Empty(t, getHeaderRaw(headers, "anthropic-beta"))
+}
+
+func TestClaudeAPIKeyFastModeWireEncoding(t *testing.T) {
+	svc := &GatewayService{resolver: fastModeTestResolver()}
+	account := &Account{Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	forceOnCtx := fastModeTestContext(APIKeyFastModePolicyForceOn, "claude-opus-4.8")
+	body, headers, err := svc.applyClaudeAPIKeyFastMode(forceOnCtx, account, "claude-opus-4.8", []byte(`{"model":"claude-opus-4.8"}`), http.Header{})
+	require.NoError(t, err)
+	require.Equal(t, "fast", gjson.GetBytes(body, "speed").String())
+	require.True(t, containsBetaToken(getHeaderRaw(headers, "anthropic-beta"), claude.BetaFastMode))
+
+	forceOffCtx := fastModeTestContext(APIKeyFastModePolicyForceOff, "claude-opus-4.8")
+	setHeaderRaw(headers, "anthropic-beta", claude.BetaFastMode+",context-management-2025-06-27")
+	body, headers, err = svc.applyClaudeAPIKeyFastMode(forceOffCtx, account, "claude-opus-4.8", body, headers)
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(body, "speed").Exists())
+	require.False(t, containsBetaToken(getHeaderRaw(headers, "anthropic-beta"), claude.BetaFastMode))
+	require.True(t, containsBetaToken(getHeaderRaw(headers, "anthropic-beta"), "context-management-2025-06-27"))
+}
+
+func TestClaudeAPIKeyFastModeCannotBypassSystemFilter(t *testing.T) {
+	cfg := &config.Config{}
+	svc := &GatewayService{
+		cfg:      cfg,
+		resolver: fastModeTestResolver(),
+	}
+	account := &Account{Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	ctx := fastModeTestContext(APIKeyFastModePolicyForceOn, "claude-opus-4.8")
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil).WithContext(ctx)
+	// 模拟系统 Beta 策略已将 Claude Fast token 标记为过滤。
+	c.Set(betaPolicyFilterSetKey, map[string]struct{}{claude.BetaFastMode: {}})
+
+	req, wireBody, err := svc.buildUpstreamRequest(ctx, c, account, []byte(`{"model":"claude-opus-4.8","messages":[]}`), "test-key", "apikey", "claude-opus-4.8", false, false)
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(wireBody, "speed").Exists())
+	require.False(t, containsBetaToken(getHeaderRaw(req.Header, "anthropic-beta"), claude.BetaFastMode))
+}
+
+func TestClaudeUsageSpeedDrivesFastBilling(t *testing.T) {
+	billing := NewBillingService(&config.Config{}, nil)
+	svc := &GatewayService{billingService: billing, resolver: NewModelPricingResolver(nil, billing)}
+	groupID := int64(11)
+	apiKey := &APIKey{GroupID: &groupID, Group: &Group{ID: groupID}}
+	account := &Account{Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	base := &ForwardResult{Usage: ClaudeUsage{InputTokens: 1000, OutputTokens: 100}, Model: "claude-opus-4.8"}
+	fast := *base
+	fast.Usage.Speed = "fast"
+
+	baseCost := svc.calculateTokenCost(context.Background(), base, apiKey, account, "claude-opus-4.8", "claude-opus-4.8", "", "", 1, nil)
+	fastCost := svc.calculateTokenCost(context.Background(), &fast, apiKey, account, "claude-opus-4.8", "claude-opus-4.8", "", "", 1, nil)
+	require.InDelta(t, baseCost.ActualCost*2, fastCost.ActualCost, 1e-12)
+	require.Equal(t, OpenAIFastTierPriority, claudeUsageServiceTier(fast.Usage.Speed))
+}
+
+func TestClaudeUsageSpeedParsing(t *testing.T) {
+	svc := &GatewayService{}
+	usage := &ClaudeUsage{}
+	svc.parseSSEUsage(`{"type":"message_start","message":{"usage":{"input_tokens":10,"speed":"fast"}}}`, usage)
+	require.Equal(t, "fast", usage.Speed)
+
+	parsed := parseClaudeUsageFromResponseBody([]byte(`{"usage":{"input_tokens":10,"output_tokens":2,"speed":"standard"}}`))
+	require.Equal(t, "standard", parsed.Speed)
+}

--- a/backend/internal/service/api_key_service.go
+++ b/backend/internal/service/api_key_service.go
@@ -23,15 +23,16 @@ import (
 )
 
 var (
-	ErrAPIKeyNotFound             = infraerrors.NotFound("API_KEY_NOT_FOUND", "api key not found")
-	ErrGroupNotAllowed            = infraerrors.Forbidden("GROUP_NOT_ALLOWED", "user is not allowed to bind this group")
-	ErrGroupDisabledForUser       = infraerrors.Forbidden("GROUP_DISABLED_FOR_USER", "user is not allowed to use this public group")
-	ErrAPIKeyExists               = infraerrors.Conflict("API_KEY_EXISTS", "api key already exists")
-	ErrAPIKeyTooShort             = infraerrors.BadRequest("API_KEY_TOO_SHORT", "api key must be at least 16 characters")
-	ErrAPIKeyInvalidChars         = infraerrors.BadRequest("API_KEY_INVALID_CHARS", "api key can only contain letters, numbers, underscores, and hyphens")
-	ErrAPIKeyRateLimited          = infraerrors.TooManyRequests("API_KEY_RATE_LIMITED", "too many failed attempts, please try again later")
-	ErrInvalidIPPattern           = infraerrors.BadRequest("INVALID_IP_PATTERN", "invalid IP or CIDR pattern")
-	ErrDataSharingConsentRequired = infraerrors.Forbidden("DATA_SHARING_CONSENT_REQUIRED", "switching to a data sharing group requires confirmation")
+	ErrAPIKeyNotFound              = infraerrors.NotFound("API_KEY_NOT_FOUND", "api key not found")
+	ErrGroupNotAllowed             = infraerrors.Forbidden("GROUP_NOT_ALLOWED", "user is not allowed to bind this group")
+	ErrGroupDisabledForUser        = infraerrors.Forbidden("GROUP_DISABLED_FOR_USER", "user is not allowed to use this public group")
+	ErrAPIKeyExists                = infraerrors.Conflict("API_KEY_EXISTS", "api key already exists")
+	ErrAPIKeyTooShort              = infraerrors.BadRequest("API_KEY_TOO_SHORT", "api key must be at least 16 characters")
+	ErrAPIKeyInvalidChars          = infraerrors.BadRequest("API_KEY_INVALID_CHARS", "api key can only contain letters, numbers, underscores, and hyphens")
+	ErrAPIKeyRateLimited           = infraerrors.TooManyRequests("API_KEY_RATE_LIMITED", "too many failed attempts, please try again later")
+	ErrInvalidIPPattern            = infraerrors.BadRequest("INVALID_IP_PATTERN", "invalid IP or CIDR pattern")
+	ErrInvalidAPIKeyFastModePolicy = infraerrors.BadRequest("INVALID_API_KEY_FAST_MODE_POLICY", "invalid API key fast mode policy")
+	ErrDataSharingConsentRequired  = infraerrors.Forbidden("DATA_SHARING_CONSENT_REQUIRED", "switching to a data sharing group requires confirmation")
 	// ErrAPIKeyExpired        = infraerrors.Forbidden("API_KEY_EXPIRED", "api key has expired")
 	ErrAPIKeyExpired = infraerrors.Forbidden("API_KEY_EXPIRED", "api key 已过期")
 	// ErrAPIKeyQuotaExhausted = infraerrors.TooManyRequests("API_KEY_QUOTA_EXHAUSTED", "api key quota exhausted")
@@ -166,6 +167,8 @@ type CreateAPIKeyRequest struct {
 	CustomKey   *string  `json:"custom_key"`   // 可选的自定义key
 	IPWhitelist []string `json:"ip_whitelist"` // IP 白名单
 	IPBlacklist []string `json:"ip_blacklist"` // IP 黑名单
+	// FastModePolicy 为空时默认跟随下游请求。
+	FastModePolicy string `json:"fast_mode_policy"`
 
 	// Quota fields
 	Quota         float64 `json:"quota"`           // Quota limit in USD (0 = unlimited)
@@ -191,6 +194,8 @@ type UpdateAPIKeyRequest struct {
 	Status      *string  `json:"status"`
 	IPWhitelist []string `json:"ip_whitelist"` // IP 白名单（空数组清空）
 	IPBlacklist []string `json:"ip_blacklist"` // IP 黑名单（空数组清空）
+	// FastModePolicy 为 nil 时保持原值。
+	FastModePolicy *string `json:"fast_mode_policy"`
 
 	// Quota fields
 	Quota           *float64   `json:"quota"`       // Quota limit in USD (nil = no change, 0 = unlimited)
@@ -385,6 +390,11 @@ func (s *APIKeyService) canUserUseBoundGroup(ctx context.Context, apiKey *APIKey
 
 // Create 创建API Key
 func (s *APIKeyService) Create(ctx context.Context, userID int64, req CreateAPIKeyRequest) (*APIKey, error) {
+	fastModePolicy, ok := NormalizeAPIKeyFastModePolicy(req.FastModePolicy)
+	if !ok {
+		return nil, ErrInvalidAPIKeyFastModePolicy
+	}
+
 	// 验证用户存在
 	user, err := s.userRepo.GetByID(ctx, userID)
 	if err != nil {
@@ -478,6 +488,7 @@ func (s *APIKeyService) Create(ctx context.Context, userID int64, req CreateAPIK
 		Name:                                  html.EscapeString(req.Name),
 		GroupID:                               req.GroupID,
 		Status:                                StatusActive,
+		FastModePolicy:                        fastModePolicy,
 		IPWhitelist:                           req.IPWhitelist,
 		IPBlacklist:                           req.IPBlacklist,
 		Quota:                                 req.Quota,
@@ -883,6 +894,13 @@ func (s *APIKeyService) Update(ctx context.Context, id int64, userID int64, req 
 	// 更新字段
 	if req.Name != nil {
 		apiKey.Name = html.EscapeString(*req.Name)
+	}
+	if req.FastModePolicy != nil {
+		fastModePolicy, ok := NormalizeAPIKeyFastModePolicy(*req.FastModePolicy)
+		if !ok {
+			return nil, ErrInvalidAPIKeyFastModePolicy
+		}
+		apiKey.FastModePolicy = fastModePolicy
 	}
 
 	if req.GroupID != nil {

--- a/backend/internal/service/api_key_service_cache_test.go
+++ b/backend/internal/service/api_key_service_cache_test.go
@@ -702,12 +702,13 @@ func TestAPIKeyService_SnapshotRoundTrip_PreservesMessagesDispatchModelConfig(t 
 	svc := NewAPIKeyService(nil, nil, nil, nil, nil, nil, &config.Config{})
 	groupID := int64(9)
 	apiKey := &APIKey{
-		ID:      1,
-		UserID:  2,
-		GroupID: &groupID,
-		Key:     "k-roundtrip",
-		Name:    "Audit Key",
-		Status:  StatusActive,
+		ID:             1,
+		UserID:         2,
+		GroupID:        &groupID,
+		Key:            "k-roundtrip",
+		Name:           "Audit Key",
+		Status:         StatusActive,
+		FastModePolicy: APIKeyFastModePolicyForceOn,
 		User: &User{
 			ID:          2,
 			Status:      StatusActive,
@@ -739,6 +740,7 @@ func TestAPIKeyService_SnapshotRoundTrip_PreservesMessagesDispatchModelConfig(t 
 
 	require.NotNil(t, roundTrip)
 	require.Equal(t, apiKey.Name, roundTrip.Name)
+	require.Equal(t, APIKeyFastModePolicyForceOn, roundTrip.FastModePolicy)
 	require.NotNil(t, roundTrip.Group)
 	require.Equal(t, apiKey.Group.MessagesDispatchModelConfig, roundTrip.Group.MessagesDispatchModelConfig)
 }

--- a/backend/internal/service/api_key_service_name_sanitize_test.go
+++ b/backend/internal/service/api_key_service_name_sanitize_test.go
@@ -162,6 +162,14 @@ func TestAPIKeyService_Create_DefaultsGroupFallbackEnabled(t *testing.T) {
 	require.True(t, created.FallbackToDefaultGroupWhenUnavailable)
 	require.Len(t, repo.created, 1)
 	require.True(t, repo.created[0].FallbackToDefaultGroupWhenUnavailable)
+	require.Equal(t, APIKeyFastModePolicyFollowRequest, created.FastModePolicy)
+}
+
+func TestAPIKeyService_CreateRejectsInvalidFastModePolicy(t *testing.T) {
+	svc := &APIKeyService{}
+
+	_, err := svc.Create(context.Background(), 7, CreateAPIKeyRequest{FastModePolicy: "invalid"})
+	require.ErrorIs(t, err, ErrInvalidAPIKeyFastModePolicy)
 }
 
 func TestAPIKeyService_Create_AllowsDisablingGroupFallback(t *testing.T) {
@@ -198,4 +206,17 @@ func TestAPIKeyService_Update_EscapesNameBeforePersist(t *testing.T) {
 	require.Equal(t, "&lt;script&gt;alert(&#34;x&#34;)&lt;/script&gt;", updated.Name)
 	require.Len(t, repo.updated, 1)
 	require.Equal(t, "&lt;script&gt;alert(&#34;x&#34;)&lt;/script&gt;", repo.updated[0].Name)
+}
+
+func TestAPIKeyService_UpdatePersistsFastModePolicy(t *testing.T) {
+	repo := &apiKeyNameSanitizeRepoStub{
+		apiKey: &APIKey{ID: 11, UserID: 7, Key: "sk_existing_key_02", Name: "old", Status: StatusActive, FastModePolicy: APIKeyFastModePolicyFollowRequest},
+	}
+	svc := &APIKeyService{apiKeyRepo: repo}
+	policy := APIKeyFastModePolicyForceOff
+
+	updated, err := svc.Update(context.Background(), 11, 7, UpdateAPIKeyRequest{FastModePolicy: &policy})
+	require.NoError(t, err)
+	require.Equal(t, APIKeyFastModePolicyForceOff, updated.FastModePolicy)
+	require.Equal(t, APIKeyFastModePolicyForceOff, repo.updated[0].FastModePolicy)
 }

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -1191,15 +1191,20 @@ func (s *BillingService) CalculateCostWithConfig(model string, tokens UsageToken
 // 拆分为：范围内 (200k, 0) + 范围外 (10k, 10k)
 // 范围内正常计费，范围外 × 2 计费
 func (s *BillingService) CalculateCostWithLongContext(model string, tokens UsageTokens, rateMultiplier float64, threshold int, extraMultiplier float64) (*CostBreakdown, error) {
+	return s.CalculateCostWithLongContextAndServiceTier(model, tokens, rateMultiplier, threshold, extraMultiplier, "")
+}
+
+// CalculateCostWithLongContextAndServiceTier 同时应用长上下文与 Fast/Flex 层级价格。
+func (s *BillingService) CalculateCostWithLongContextAndServiceTier(model string, tokens UsageTokens, rateMultiplier float64, threshold int, extraMultiplier float64, serviceTier string) (*CostBreakdown, error) {
 	// 未启用长上下文计费，直接走正常计费
 	if threshold <= 0 || extraMultiplier <= 1 {
-		return s.CalculateCost(model, tokens, rateMultiplier)
+		return s.CalculateCostWithServiceTier(model, tokens, rateMultiplier, serviceTier)
 	}
 
 	// 计算总输入 token（缓存读取 + 新输入）
 	total := tokens.CacheReadTokens + tokens.InputTokens
 	if total <= threshold {
-		return s.CalculateCost(model, tokens, rateMultiplier)
+		return s.CalculateCostWithServiceTier(model, tokens, rateMultiplier, serviceTier)
 	}
 
 	// 拆分成范围内和范围外
@@ -1230,7 +1235,7 @@ func (s *BillingService) CalculateCostWithLongContext(model string, tokens Usage
 		CacheCreation1hTokens: tokens.CacheCreation1hTokens,
 		ImageOutputTokens:     tokens.ImageOutputTokens,
 	}
-	inRangeCost, err := s.CalculateCost(model, inRangeTokens, rateMultiplier)
+	inRangeCost, err := s.CalculateCostWithServiceTier(model, inRangeTokens, rateMultiplier, serviceTier)
 	if err != nil {
 		return nil, err
 	}
@@ -1240,7 +1245,7 @@ func (s *BillingService) CalculateCostWithLongContext(model string, tokens Usage
 		InputTokens:     outRangeInputTokens,
 		CacheReadTokens: outRangeCacheTokens,
 	}
-	outRangeCost, err := s.CalculateCost(model, outRangeTokens, rateMultiplier*extraMultiplier)
+	outRangeCost, err := s.CalculateCostWithServiceTier(model, outRangeTokens, rateMultiplier*extraMultiplier, serviceTier)
 	if err != nil {
 		return inRangeCost, fmt.Errorf("out-range cost: %w", err)
 	}

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/TokenFlux/TokenRouter/internal/pkg/claude"
 	"github.com/TokenFlux/TokenRouter/internal/pkg/logger"
 	"github.com/TokenFlux/TokenRouter/internal/util/responseheaders"
 	"github.com/tidwall/gjson"
@@ -92,6 +93,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	}
 
 	var resp *http.Response
+	lastWireBody := input.Body
 	retryStart := time.Now()
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
 		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, input.RequestStream)
@@ -100,6 +102,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 		if err != nil {
 			return nil, err
 		}
+		lastWireBody = wireBody
 		if input.Parsed != nil && !bytes.Equal(wireBody, input.Body) {
 			// build 阶段会按 beta 能力清理 body，发送前同步到 ParsedRequest 当前视图。
 			if err := input.Parsed.ReplaceBody(wireBody); err != nil {
@@ -283,6 +286,9 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	if usage == nil {
 		usage = &ClaudeUsage{}
 	}
+	if strings.TrimSpace(usage.Speed) == "" && strings.EqualFold(strings.TrimSpace(gjson.GetBytes(lastWireBody, "speed").String()), "fast") {
+		usage.Speed = "fast"
+	}
 
 	return &ForwardResult{
 		RequestID:        resp.Header.Get("x-request-id"),
@@ -314,16 +320,29 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 		targetURL = validatedURL + "/v1/messages?beta=true"
 	}
 
-	// 能力维度 body sanitize：透传路径上 anthropic-beta header 原样透传客户端值，
-	// 依此决定是否保留 body 中的 context_management。避免“客户端 body 带字段但
-	// header 忘记带 beta token”的客户端 bug 在透传场景下让上游 400。
-	clientBeta := ""
+	clientHeaders := http.Header{}
 	if c != nil && c.Request != nil {
-		clientBeta = getHeaderRaw(c.Request.Header, "anthropic-beta")
+		clientHeaders = c.Request.Header
 	}
+	model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	originalPolicy := s.evaluateBetaPolicy(ctx, getHeaderRaw(clientHeaders, "anthropic-beta"), account, model)
+	if originalPolicy.blockErr != nil {
+		return nil, nil, originalPolicy.blockErr
+	}
+	var err error
+	body, clientHeaders, err = s.applyClaudeAPIKeyFastMode(ctx, account, model, body, clientHeaders)
+	if err != nil {
+		return nil, nil, err
+	}
+	clientBeta := stripBetaTokensWithSet(getHeaderRaw(clientHeaders, "anthropic-beta"), originalPolicy.filterSet)
 	// 账号覆写了 anthropic-beta 时，覆写值即最终上游值：净化以覆写值为准
 	if beta, ok := account.HeaderOverrideValue("anthropic-beta"); ok {
 		clientBeta = beta
+	}
+	if containsBetaToken(clientBeta, claude.BetaFastMode) {
+		if blockErr := s.checkBetaPolicyBlockForTokens(ctx, []string{claude.BetaFastMode}, account, model); blockErr != nil {
+			return nil, nil, blockErr
+		}
 	}
 	if sanitized, changed := sanitizeAnthropicBodyForBetaTokens(body, clientBeta); changed {
 		body = sanitized
@@ -334,8 +353,8 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 		return nil, nil, err
 	}
 
-	if c != nil && c.Request != nil {
-		for key, values := range c.Request.Header {
+	if clientHeaders != nil {
+		for key, values := range clientHeaders {
 			lowerKey := strings.ToLower(strings.TrimSpace(key))
 			if !allowedHeaders[lowerKey] {
 				continue
@@ -345,6 +364,11 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 				addHeaderRaw(req.Header, wireKey, v)
 			}
 		}
+	}
+	// 透传白名单可能写入 Key 改写前的值，按系统策略裁决后的 beta 覆盖。
+	deleteHeaderAllForms(req.Header, "anthropic-beta")
+	if clientBeta != "" {
+		setHeaderRaw(req.Header, "anthropic-beta", clientBeta)
 	}
 
 	// 覆盖入站鉴权残留，并注入上游认证
@@ -644,6 +668,9 @@ func (s *GatewayService) parseSSEUsagePassthrough(data string, usage *ClaudeUsag
 	case "message_start":
 		msgUsage := parsed.Get("message.usage")
 		if msgUsage.Exists() {
+			if speed := strings.TrimSpace(msgUsage.Get("speed").String()); speed != "" {
+				usage.Speed = speed
+			}
 			usage.InputTokens = int(msgUsage.Get("input_tokens").Int())
 			usage.CacheCreationInputTokens = int(msgUsage.Get("cache_creation_input_tokens").Int())
 			usage.CacheReadInputTokens = int(msgUsage.Get("cache_read_input_tokens").Int())
@@ -659,6 +686,9 @@ func (s *GatewayService) parseSSEUsagePassthrough(data string, usage *ClaudeUsag
 	case "message_delta":
 		deltaUsage := parsed.Get("usage")
 		if deltaUsage.Exists() {
+			if speed := strings.TrimSpace(deltaUsage.Get("speed").String()); speed != "" {
+				usage.Speed = speed
+			}
 			if v := deltaUsage.Get("input_tokens").Int(); v > 0 {
 				usage.InputTokens = int(v)
 			}
@@ -721,6 +751,7 @@ func parseClaudeUsageFromResponseBody(body []byte) *ClaudeUsage {
 	usage.OutputTokens = int(usageNode.Get("output_tokens").Int())
 	usage.CacheCreationInputTokens = int(usageNode.Get("cache_creation_input_tokens").Int())
 	usage.CacheReadInputTokens = int(usageNode.Get("cache_read_input_tokens").Int())
+	usage.Speed = strings.TrimSpace(usageNode.Get("speed").String())
 
 	cc5m := usageNode.Get("cache_creation.ephemeral_5m_input_tokens").Int()
 	cc1h := usageNode.Get("cache_creation.ephemeral_1h_input_tokens").Int()

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -353,16 +353,14 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 		return nil, nil, err
 	}
 
-	if clientHeaders != nil {
-		for key, values := range clientHeaders {
-			lowerKey := strings.ToLower(strings.TrimSpace(key))
-			if !allowedHeaders[lowerKey] {
-				continue
-			}
-			wireKey := resolveWireCasing(key)
-			for _, v := range values {
-				addHeaderRaw(req.Header, wireKey, v)
-			}
+	for key, values := range clientHeaders {
+		lowerKey := strings.ToLower(strings.TrimSpace(key))
+		if !allowedHeaders[lowerKey] {
+			continue
+		}
+		wireKey := resolveWireCasing(key)
+		for _, v := range values {
+			addHeaderRaw(req.Header, wireKey, v)
 		}
 	}
 	// 透传白名单可能写入 Key 改写前的值，按系统策略裁决后的 beta 覆盖。

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -16,6 +16,7 @@ import (
 	"github.com/TokenFlux/TokenRouter/internal/pkg/logger"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 )
 
 // 重试相关常量
@@ -778,6 +779,12 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			return nil, err
 		}
 		responseBody = body
+	}
+	if usage == nil {
+		usage = &ClaudeUsage{}
+	}
+	if strings.TrimSpace(usage.Speed) == "" && strings.EqualFold(strings.TrimSpace(gjson.GetBytes(lastWireBody, "speed").String()), "fast") {
+		usage.Speed = "fast"
 	}
 
 	return &ForwardResult{

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -119,7 +119,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 10. Build upstream request
 	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
-	upstreamReq, _, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
+	upstreamReq, wireBody, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
 	releaseUpstreamCtx()
 	if err != nil {
 		return nil, fmt.Errorf("build upstream request: %w", err)
@@ -193,6 +193,10 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		result, handleErr = s.handleCCBufferedFromAnthropic(resp, c, originalModel, mappedModel, reasoningEffort, startTime)
 	}
 
+	if result != nil && strings.TrimSpace(result.Usage.Speed) == "" &&
+		strings.EqualFold(strings.TrimSpace(gjson.GetBytes(wireBody, "speed").String()), "fast") {
+		result.Usage.Speed = "fast"
+	}
 	return result, handleErr
 }
 

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -118,7 +118,7 @@ func (s *GatewayService) ForwardAsResponses(
 
 	// 10. Build upstream request
 	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
-	upstreamReq, _, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
+	upstreamReq, wireBody, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
 	releaseUpstreamCtx()
 	if err != nil {
 		return nil, fmt.Errorf("build upstream request: %w", err)
@@ -187,6 +187,10 @@ func (s *GatewayService) ForwardAsResponses(
 		result, handleErr = s.handleResponsesBufferedStreamingResponse(resp, c, originalModel, mappedModel, reasoningEffort, startTime)
 	}
 
+	if result != nil && strings.TrimSpace(result.Usage.Speed) == "" &&
+		strings.EqualFold(strings.TrimSpace(gjson.GetBytes(wireBody, "speed").String()), "fast") {
+		result.Usage.Speed = "fast"
+	}
 	return result, handleErr
 }
 
@@ -219,6 +223,9 @@ func mergeAnthropicUsage(dst *ClaudeUsage, src apicompat.AnthropicUsage) {
 	}
 	if src.CacheCreationInputTokens > 0 {
 		dst.CacheCreationInputTokens = src.CacheCreationInputTokens
+	}
+	if strings.TrimSpace(src.Speed) != "" {
+		dst.Speed = src.Speed
 	}
 }
 

--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/TokenFlux/TokenRouter/internal/domain"
 	"github.com/TokenFlux/TokenRouter/internal/pkg/antigravity"
+	"github.com/TokenFlux/TokenRouter/internal/pkg/claude"
 	"github.com/TokenFlux/TokenRouter/internal/pkg/logger"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -872,23 +873,28 @@ func sanitizeAnthropicBodyForBetaTokens(body []byte, anthropicBetaHeader string)
 	if len(body) == 0 {
 		return body, false
 	}
-	if !gjson.GetBytes(body, "context_management").Exists() {
-		return body, false
+	updated := body
+	changed := false
+	if gjson.GetBytes(updated, "context_management").Exists() &&
+		!anthropicBetaTokensContains(anthropicBetaHeader, anthropicBetaContextManagementToken) {
+		if b, err := sjson.DeleteBytes(updated, "context_management"); err == nil {
+			updated = b
+			changed = true
+		} else {
+			logger.LegacyPrintf("service.gateway", "[CtxMgmtSanitize] 删除 context_management 失败: %v (body len=%d)", err, len(body))
+		}
 	}
-	if anthropicBetaTokensContains(anthropicBetaHeader, anthropicBetaContextManagementToken) {
-		return body, false
+	// Claude Fast 要求 speed 与 beta token 同时存在；系统过滤 beta 后必须同步删除 speed。
+	if strings.EqualFold(strings.TrimSpace(gjson.GetBytes(updated, "speed").String()), "fast") &&
+		!anthropicBetaTokensContains(anthropicBetaHeader, claude.BetaFastMode) {
+		if b, err := sjson.DeleteBytes(updated, "speed"); err == nil {
+			updated = b
+			changed = true
+		} else {
+			logger.LegacyPrintf("service.gateway", "[FastModeSanitize] 删除 speed 失败: %v (body len=%d)", err, len(body))
+		}
 	}
-	if b, err := sjson.DeleteBytes(body, "context_management"); err == nil {
-		return b, true
-	} else {
-		// 不应发生：gjson 刚验证过字段存在 + body 是合法 JSON。如果 sjson 仍报错，
-		// 调用方会拿到 (body, false)，但此前 computeFinalAnthropicBeta 已按“strip 后”
-		// 计算了 finalBeta——两侧会不一致。记录 warning 最小限度提醒运维。
-		logger.LegacyPrintf("service.gateway",
-			"[CtxMgmtSanitize] sjson.DeleteBytes failed unexpectedly: %v (body len=%d). "+
-				"body and final anthropic-beta header may be out of sync.", err, len(body))
-	}
-	return body, false
+	return updated, changed
 }
 
 // anthropicBetaTokensContains 检测逗号分隔的 anthropic-beta header 是否含指定 token。

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -539,6 +539,8 @@ type ClaudeUsage struct {
 	CacheCreation5mTokens    int // 5分钟缓存创建token（来自嵌套 cache_creation 对象）
 	CacheCreation1hTokens    int // 1小时缓存创建token（来自嵌套 cache_creation 对象）
 	ImageOutputTokens        int `json:"image_output_tokens,omitempty"`
+	// Speed 记录 Claude 实际返回的处理速度，"fast" 会映射到内部 priority 计费。
+	Speed string `json:"speed,omitempty"`
 }
 
 // ForwardResult 转发结果

--- a/backend/internal/service/gateway_upstream_request.go
+++ b/backend/internal/service/gateway_upstream_request.go
@@ -51,6 +51,11 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 	if c != nil && c.Request != nil {
 		clientHeaders = c.Request.Header
 	}
+	var err error
+	body, clientHeaders, err = s.applyClaudeAPIKeyFastMode(ctx, account, modelID, body, clientHeaders)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// OAuth账号：应用统一指纹和metadata重写（受设置开关控制）
 	var fingerprint *Fingerprint
@@ -107,6 +112,11 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 	// body 能力净化必须以覆写值为准，否则 header/body 不对称会被上游 400。
 	if beta, ok := account.HeaderOverrideValue("anthropic-beta"); ok {
 		finalBetaHeader, finalBetaShouldSet = beta, true
+	}
+	if containsBetaToken(finalBetaHeader, claude.BetaFastMode) {
+		if blockErr := s.checkBetaPolicyBlockForTokens(ctx, []string{claude.BetaFastMode}, account, modelID); blockErr != nil {
+			return nil, nil, blockErr
+		}
 	}
 
 	// 能力维度 body sanitize：与最终 anthropic-beta header 对称

--- a/backend/internal/service/gateway_upstream_response.go
+++ b/backend/internal/service/gateway_upstream_response.go
@@ -1128,6 +1128,8 @@ type sseUsagePatch struct {
 	hasCacheCreation5m       bool
 	cacheCreation1hTokens    int
 	hasCacheCreation1h       bool
+	speed                    string
+	hasSpeed                 bool
 }
 
 func (s *GatewayService) extractSSEUsagePatch(event map[string]any) *sseUsagePatch {
@@ -1145,6 +1147,10 @@ func (s *GatewayService) extractSSEUsagePatch(event map[string]any) *sseUsagePat
 		}
 
 		patch := &sseUsagePatch{}
+		if speed, ok := usageObj["speed"].(string); ok && strings.TrimSpace(speed) != "" {
+			patch.speed = speed
+			patch.hasSpeed = true
+		}
 		patch.hasInputTokens = true
 		if v, ok := parseSSEUsageInt(usageObj["input_tokens"]); ok {
 			patch.inputTokens = v
@@ -1176,6 +1182,10 @@ func (s *GatewayService) extractSSEUsagePatch(event map[string]any) *sseUsagePat
 		}
 
 		patch := &sseUsagePatch{}
+		if speed, ok := usageObj["speed"].(string); ok && strings.TrimSpace(speed) != "" {
+			patch.speed = speed
+			patch.hasSpeed = true
+		}
 		if v, ok := parseSSEUsageInt(usageObj["input_tokens"]); ok && v > 0 {
 			patch.inputTokens = v
 			patch.hasInputTokens = true
@@ -1215,6 +1225,9 @@ func mergeSSEUsagePatch(usage *ClaudeUsage, patch *sseUsagePatch) {
 
 	if patch.hasInputTokens {
 		usage.InputTokens = patch.inputTokens
+	}
+	if patch.hasSpeed {
+		usage.Speed = patch.speed
 	}
 	if patch.hasCacheCreationInput {
 		usage.CacheCreationInputTokens = patch.cacheCreationInputTokens

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -769,6 +769,7 @@ func (s *GatewayService) calculateTokenCost(
 	multiplier float64,
 	opts *recordUsageOpts,
 ) *CostBreakdown {
+	serviceTier := claudeUsageServiceTier(result.Usage.Speed)
 	tokens := UsageTokens{
 		InputTokens:           result.Usage.InputTokens,
 		OutputTokens:          result.Usage.OutputTokens,
@@ -792,6 +793,7 @@ func (s *GatewayService) calculateTokenCost(
 			Tokens:         tokens,
 			RequestCount:   1,
 			RateMultiplier: multiplier,
+			ServiceTier:    serviceTier,
 			Resolver:       s.resolver,
 			Resolved:       resolved,
 		})
@@ -802,9 +804,9 @@ func (s *GatewayService) calculateTokenCost(
 			}
 			if opts.LongContextThreshold > 0 {
 				// 长上下文双倍计费（如 Gemini 200K 阈值）
-				return s.billingService.CalculateCostWithLongContext(model, tokens, multiplier, opts.LongContextThreshold, opts.LongContextMultiplier)
+				return s.billingService.CalculateCostWithLongContextAndServiceTier(model, tokens, multiplier, opts.LongContextThreshold, opts.LongContextMultiplier, serviceTier)
 			}
-			return s.billingService.CalculateCost(model, tokens, multiplier)
+			return s.billingService.CalculateCostWithServiceTier(model, tokens, multiplier, serviceTier)
 		}
 		if isQoderBillingContext(account, apiKey) {
 			for _, model := range qoderDefaultPricingCandidates(billingModel, requestedModel, billingModelSource) {
@@ -855,6 +857,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		RequestedModel:        requestedModel,
 		UpstreamModel:         optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
 		ReasoningEffort:       result.ReasoningEffort,
+		ServiceTier:           optionalTrimmedStringPtr(claudeUsageServiceTier(result.Usage.Speed)),
 		InboundEndpoint:       optionalTrimmedStringPtr(input.InboundEndpoint),
 		UpstreamEndpoint:      optionalTrimmedStringPtr(input.UpstreamEndpoint),
 		InputTokens:           result.Usage.InputTokens,
@@ -900,6 +903,14 @@ func (s *GatewayService) buildRecordUsageLog(
 	}
 
 	return usageLog
+}
+
+// claudeUsageServiceTier 将 Claude usage.speed 复用为内部统一的 Fast 计费层级。
+func claudeUsageServiceTier(speed string) string {
+	if strings.EqualFold(strings.TrimSpace(speed), "fast") {
+		return OpenAIFastTierPriority
+	}
+	return ""
 }
 
 // resolveBillingMode 根据计费结果和请求类型确定计费模式。

--- a/backend/internal/service/model_pricing_resolver.go
+++ b/backend/internal/service/model_pricing_resolver.go
@@ -177,6 +177,10 @@ func (r *ModelPricingResolver) resolveBasePricing(model string) (*ModelPricing, 
 
 // applyChannelOverrides 应用渠道定价覆盖
 func (r *ModelPricingResolver) applyChannelOverrides(ctx context.Context, groupID int64, model string, resolved *ResolvedPricing) {
+	// 精简构造或测试环境可能未注入渠道服务，此时只使用基础模型定价。
+	if r == nil || r.channelService == nil {
+		return
+	}
 	chPricing := r.channelService.GetEffectiveChannelModelPricing(ctx, groupID, model)
 	if chPricing == nil {
 		return

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -399,30 +399,15 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
-	if rawTier := requestView.ServiceTier; rawTier != "" {
-		if normTier := normalizedOpenAIServiceTierValue(rawTier); normTier != "" {
-			action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, upstreamModel, normTier)
-			switch action {
-			case BetaPolicyActionBlock:
-				msg := errMsg
-				if msg == "" {
-					msg = fmt.Sprintf("openai service_tier=%s is not allowed for model %s", normTier, upstreamModel)
-				}
-				blocked := &OpenAIFastBlockedError{Message: msg}
-				writeOpenAIFastPolicyBlockedResponse(c, blocked)
-				return nil, blocked
-			case BetaPolicyActionFilter:
-				markPatchDelete("service_tier")
-			case OpenAIFastPolicyActionForcePriority:
-				if rawTier != OpenAIFastTierPriority {
-					markPatchSet("service_tier", OpenAIFastTierPriority)
-				}
-			default:
-				if normTier != rawTier {
-					markPatchSet("service_tier", normTier)
-				}
-			}
-		}
+	decision := s.resolveOpenAIFastModeDecision(ctx, account, upstreamModel, requestView.ServiceTier, requestView.HasServiceTier)
+	if decision.Blocked != nil {
+		writeOpenAIFastPolicyBlockedResponse(c, decision.Blocked)
+		return nil, decision.Blocked
+	}
+	if decision.DeleteField {
+		markPatchDelete("service_tier")
+	} else if decision.Tier != "" && decision.Tier != requestView.ServiceTier {
+		markPatchSet("service_tier", decision.Tier)
 	}
 
 	if bodyModified {

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -360,6 +360,7 @@ type openAIRequestView struct {
 	PromptCacheKey     string
 	PreviousResponseID string
 	ServiceTier        string
+	HasServiceTier     bool
 	ReasoningEffort    string
 	patches            []openAIRequestPatch
 	patchesDisabled    bool
@@ -375,13 +376,15 @@ func newOpenAIRequestView(body []byte) openAIRequestView {
 	if len(body) == 0 {
 		return openAIRequestView{}
 	}
+	serviceTier := gjson.GetBytes(body, "service_tier")
 	return openAIRequestView{
 		body:               body,
 		Model:              strings.TrimSpace(gjson.GetBytes(body, "model").String()),
 		Stream:             gjson.GetBytes(body, "stream").Bool(),
 		PromptCacheKey:     strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String()),
 		PreviousResponseID: strings.TrimSpace(gjson.GetBytes(body, "previous_response_id").String()),
-		ServiceTier:        strings.TrimSpace(gjson.GetBytes(body, "service_tier").String()),
+		ServiceTier:        strings.TrimSpace(serviceTier.String()),
+		HasServiceTier:     serviceTier.Exists(),
 		ReasoningEffort:    strings.TrimSpace(gjson.GetBytes(body, "reasoning.effort").String()),
 	}
 }
@@ -795,11 +798,77 @@ func openAIFastPolicySettingsFromContext(ctx context.Context) *OpenAIFastPolicyS
 	return nil
 }
 
-// applyOpenAIFastPolicyToBody 对原始请求体应用 OpenAI fast policy。
-// action=filter 时删除 service_tier，action=block 时返回
-// (body, *OpenAIFastBlockedError)，action=pass 时归一化 service_tier
-// （例如将客户端别名 "fast" 改为 "priority"），action=force_priority 时
-// 将所有命中的已知 tier 强制改为 "priority"。
+// openAIFastModeDecision 描述最终应写入、删除或拒绝的 OpenAI Fast 决策。
+type openAIFastModeDecision struct {
+	Tier        string
+	DeleteField bool
+	Blocked     *OpenAIFastBlockedError
+}
+
+// resolveOpenAIFastModeDecision 统一解析系统策略与单 Key 策略。
+// 系统先裁决原始 tier；Key 改写后再裁决一次，避免 force_on 绕过系统 filter/block。
+func (s *OpenAIGatewayService) resolveOpenAIFastModeDecision(
+	ctx context.Context,
+	account *Account,
+	model string,
+	rawTier string,
+	hasField bool,
+) openAIFastModeDecision {
+	normTier := normalizedOpenAIServiceTierValue(rawTier)
+	applySystemAction := func(tier string) (openAIFastModeDecision, bool) {
+		action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, model, tier)
+		switch action {
+		case BetaPolicyActionBlock:
+			if errMsg == "" {
+				errMsg = fmt.Sprintf("openai service_tier=%s is not allowed for model %s", tier, model)
+			}
+			return openAIFastModeDecision{Blocked: &OpenAIFastBlockedError{Message: errMsg}}, true
+		case BetaPolicyActionFilter:
+			return openAIFastModeDecision{DeleteField: true}, true
+		case OpenAIFastPolicyActionForcePriority:
+			return openAIFastModeDecision{Tier: OpenAIFastTierPriority}, true
+		default:
+			return openAIFastModeDecision{}, false
+		}
+	}
+
+	// 原始请求已命中的非 pass 系统动作直接生效，Key 策略不能覆盖。
+	if normTier != "" {
+		if decision, handled := applySystemAction(normTier); handled {
+			return decision
+		}
+	}
+
+	candidateTier := normTier
+	policy := apiKeyFastModePolicyFromContext(ctx)
+	keyPolicySupported := policy != APIKeyFastModePolicyFollowRequest && s.openAIAPIKeyFastModeSupported(ctx, account, model)
+	candidateChanged := false
+	if keyPolicySupported {
+		switch policy {
+		case APIKeyFastModePolicyForceOn:
+			candidateTier = OpenAIFastTierPriority
+		case APIKeyFastModePolicyForceOff:
+			candidateTier = ""
+		}
+		candidateChanged = candidateTier != normTier
+	}
+
+	// Key 注入或改写出的 tier 必须重新接受系统策略裁决。
+	if candidateTier != "" {
+		if candidateChanged {
+			if decision, handled := applySystemAction(candidateTier); handled {
+				return decision
+			}
+		}
+		return openAIFastModeDecision{Tier: candidateTier}
+	}
+	if policy == APIKeyFastModePolicyForceOff && keyPolicySupported {
+		return openAIFastModeDecision{DeleteField: hasField}
+	}
+	return openAIFastModeDecision{}
+}
+
+// applyOpenAIFastPolicyToBody 对原始请求体应用系统策略和单 Key Fast 策略。
 //
 // Rationale for normalize-on-pass: chat-completions / messages 入口在调用本
 // 函数之前已经通过 normalizeResponsesBodyServiceTier 把 service_tier 归一化
@@ -810,45 +879,26 @@ func (s *OpenAIGatewayService) applyOpenAIFastPolicyToBody(ctx context.Context, 
 	if len(body) == 0 {
 		return body, nil
 	}
-	rawTier := gjson.GetBytes(body, "service_tier").String()
-	if rawTier == "" {
-		return body, nil
+	tierResult := gjson.GetBytes(body, "service_tier")
+	decision := s.resolveOpenAIFastModeDecision(ctx, account, model, tierResult.String(), tierResult.Exists())
+	if decision.Blocked != nil {
+		return body, decision.Blocked
 	}
-	normTier := normalizedOpenAIServiceTierValue(rawTier)
-	if normTier == "" {
-		return body, nil
-	}
-	action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, model, normTier)
-	switch action {
-	case BetaPolicyActionBlock:
-		msg := errMsg
-		if msg == "" {
-			msg = fmt.Sprintf("openai service_tier=%s is not allowed for model %s", normTier, model)
-		}
-		return body, &OpenAIFastBlockedError{Message: msg}
-	case BetaPolicyActionFilter:
+	if decision.DeleteField {
 		trimmed, err := sjson.DeleteBytes(body, "service_tier")
 		if err != nil {
 			return body, fmt.Errorf("strip service_tier from body: %w", err)
 		}
 		return trimmed, nil
-	case OpenAIFastPolicyActionForcePriority:
-		updated, err := sjson.SetBytes(body, "service_tier", OpenAIFastTierPriority)
+	}
+	if decision.Tier != "" && (!tierResult.Exists() || decision.Tier != tierResult.String()) {
+		updated, err := sjson.SetBytes(body, "service_tier", decision.Tier)
 		if err != nil {
-			return body, fmt.Errorf("force service_tier priority on body: %w", err)
-		}
-		return updated, nil
-	default:
-		// pass：把别名（如 "fast"）写回为规范值（"priority"）。
-		if normTier == rawTier {
-			return body, nil
-		}
-		updated, err := sjson.SetBytes(body, "service_tier", normTier)
-		if err != nil {
-			return body, fmt.Errorf("normalize service_tier on pass: %w", err)
+			return body, fmt.Errorf("apply service_tier to body: %w", err)
 		}
 		return updated, nil
 	}
+	return body, nil
 }
 
 // writeOpenAIFastPolicyBlockedResponse writes a 403 JSON response for a
@@ -920,46 +970,26 @@ func (s *OpenAIGatewayService) applyOpenAIFastPolicyToWSResponseCreate(
 	if frameType != "response.create" {
 		return frame, nil, nil
 	}
-	rawTier := gjson.GetBytes(frame, "service_tier").String()
-	if rawTier == "" {
-		return frame, nil, nil
+	tierResult := gjson.GetBytes(frame, "service_tier")
+	decision := s.resolveOpenAIFastModeDecision(ctx, account, model, tierResult.String(), tierResult.Exists())
+	if decision.Blocked != nil {
+		return frame, decision.Blocked, nil
 	}
-	normTier := normalizedOpenAIServiceTierValue(rawTier)
-	if normTier == "" {
-		return frame, nil, nil
-	}
-	action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, model, normTier)
-	switch action {
-	case BetaPolicyActionBlock:
-		msg := errMsg
-		if msg == "" {
-			msg = fmt.Sprintf("openai service_tier=%s is not allowed for model %s", normTier, model)
-		}
-		return frame, &OpenAIFastBlockedError{Message: msg}, nil
-	case BetaPolicyActionFilter:
+	if decision.DeleteField {
 		trimmed, err := sjson.DeleteBytes(frame, "service_tier")
 		if err != nil {
 			return frame, nil, fmt.Errorf("strip service_tier from ws frame: %w", err)
 		}
 		return trimmed, nil, nil
-	case OpenAIFastPolicyActionForcePriority:
-		updated, err := sjson.SetBytes(frame, "service_tier", OpenAIFastTierPriority)
+	}
+	if decision.Tier != "" && (!tierResult.Exists() || decision.Tier != tierResult.String()) {
+		updated, err := sjson.SetBytes(frame, "service_tier", decision.Tier)
 		if err != nil {
-			return frame, nil, fmt.Errorf("force service_tier priority in ws frame: %w", err)
-		}
-		return updated, nil, nil
-	default:
-		// pass 路径也要把客户端别名 fast 归一化为上游接受的 priority，
-		// 保持 WS 与 HTTP body 入口的 service_tier 语义一致。
-		if normTier == rawTier {
-			return frame, nil, nil
-		}
-		updated, err := sjson.SetBytes(frame, "service_tier", normTier)
-		if err != nil {
-			return frame, nil, fmt.Errorf("normalize service_tier in ws frame: %w", err)
+			return frame, nil, fmt.Errorf("apply service_tier in ws frame: %w", err)
 		}
 		return updated, nil, nil
 	}
+	return frame, nil, nil
 }
 
 // newOpenAIFastPolicyWSEventID returns a Realtime-style event_id for a

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -119,7 +119,7 @@ type UsageLog struct {
 	BillingTier *string
 	// BillingMode 计费模式：token/image
 	BillingMode *string
-	// ServiceTier records the OpenAI service tier used for billing, e.g. "priority" / "flex".
+	// ServiceTier 记录归一化后的计费层级；Claude Fast 同样使用 "priority"。
 	ServiceTier *string
 	// ReasoningEffort is the request's reasoning effort level.
 	// OpenAI: "low" / "medium" / "high" / "xhigh"; Claude: "low" / "medium" / "high" / "max".

--- a/backend/migrations/199_add_api_key_fast_mode_policy.sql
+++ b/backend/migrations/199_add_api_key_fast_mode_policy.sql
@@ -1,0 +1,18 @@
+-- 单个 API Key 的 Fast 模式策略；存量 Key 默认继续跟随下游请求。
+ALTER TABLE api_keys
+    ADD COLUMN IF NOT EXISTS fast_mode_policy VARCHAR(32) NOT NULL DEFAULT 'follow_request';
+
+-- 数据库约束防止绕过应用层写入未知策略值。
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'api_keys_fast_mode_policy_check'
+          AND conrelid = 'api_keys'::regclass
+    ) THEN
+        ALTER TABLE api_keys
+            ADD CONSTRAINT api_keys_fast_mode_policy_check
+            CHECK (fast_mode_policy IN ('follow_request', 'force_on', 'force_off'));
+    END IF;
+END $$;

--- a/frontend/src/i18n/locales/en/dashboard.ts
+++ b/frontend/src/i18n/locales/en/dashboard.ts
@@ -101,6 +101,12 @@ export default {
     namePlaceholder: 'My API Key',
     groupLabel: 'Group',
     selectGroup: 'Select a group',
+    fastModePolicyLabel: 'Fast mode policy',
+    fastModePolicy: {
+      followRequest: 'Follow request',
+      forceOn: 'Force Fast on',
+      forceOff: 'Force Fast off'
+    },
     fallbackToDefaultGroupWhenUnavailable: 'Auto fallback when unavailable',
     statusLabel: 'Status',
     selectStatus: 'Select status',

--- a/frontend/src/i18n/locales/zh/dashboard.ts
+++ b/frontend/src/i18n/locales/zh/dashboard.ts
@@ -101,6 +101,12 @@ export default {
     namePlaceholder: '我的 API 密钥',
     groupLabel: '分组',
     selectGroup: '选择分组',
+    fastModePolicyLabel: 'Fast 模式策略',
+    fastModePolicy: {
+      followRequest: '跟随请求',
+      forceOn: '强制开启 Fast',
+      forceOff: '强制关闭 Fast'
+    },
     fallbackToDefaultGroupWhenUnavailable: '不可用时自动降级',
     statusLabel: '状态',
     selectStatus: '选择状态',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -710,6 +710,9 @@ export interface ModelsListConfig {
   models: string[]
 }
 
+// 单个 API Key 的 Fast 模式策略，系统级策略拥有更高优先级。
+export type ApiKeyFastModePolicy = 'follow_request' | 'force_on' | 'force_off'
+
 export interface ApiKey {
   id: number
   user_id: number
@@ -717,6 +720,7 @@ export interface ApiKey {
   name: string
   group_id: number | null
   status: 'active' | 'inactive' | 'quota_exhausted' | 'expired'
+  fast_mode_policy: ApiKeyFastModePolicy
   ip_whitelist: string[]
   ip_blacklist: string[]
   last_used_at: string | null
@@ -749,6 +753,7 @@ export interface ApiKey {
 export interface CreateApiKeyRequest {
   name: string
   group_id?: number | null
+  fast_mode_policy?: ApiKeyFastModePolicy
   custom_key?: string // Optional custom API Key
   ip_whitelist?: string[]
   ip_blacklist?: string[]
@@ -766,6 +771,7 @@ export interface UpdateApiKeyRequest {
   name?: string
   group_id?: number | null
   status?: 'active' | 'inactive'
+  fast_mode_policy?: ApiKeyFastModePolicy
   ip_whitelist?: string[]
   ip_blacklist?: string[]
   quota?: number // Quota limit in USD (null = no change, 0 = unlimited)

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -502,6 +502,17 @@
           </Select>
         </div>
 
+        <!-- 单 Key Fast 策略使用项目统一选择框，系统策略仍在服务端最终裁决。 -->
+        <div>
+          <label class="input-label">{{ t('keys.fastModePolicyLabel') }}</label>
+          <Select
+            v-model="formData.fast_mode_policy"
+            :options="fastModePolicyOptions"
+            :placeholder="t('keys.fastModePolicyLabel')"
+            data-test="fast-mode-policy-select"
+          />
+        </div>
+
         <!-- 分组停用时的请求级自动降级开关。 -->
         <div class="flex items-center justify-between">
           <label class="input-label mb-0">{{ t('keys.fallbackToDefaultGroupWhenUnavailable') }}</label>
@@ -1181,7 +1192,7 @@ import TablePageLayout from '@/components/layout/TablePageLayout.vue'
 	import EndpointPopover from '@/components/keys/EndpointPopover.vue'
 	import GroupBadge from '@/components/common/GroupBadge.vue'
 	import GroupOptionItem from '@/components/common/GroupOptionItem.vue'
-	import type { ApiKey, Group, PublicSettings, GroupPlatform, UpdateApiKeyRequest } from '@/types'
+	import type { ApiKey, ApiKeyFastModePolicy, Group, PublicSettings, GroupPlatform, UpdateApiKeyRequest } from '@/types'
 import type { Column } from '@/components/common/types'
 import type { BatchApiKeyUsageStats } from '@/api/usage'
 import type { DataShareNotice } from '@/api/dataSharing'
@@ -1407,6 +1418,7 @@ const formData = ref({
   name: '',
   group_id: null as number | null,
   status: 'active' as 'active' | 'inactive',
+  fast_mode_policy: 'follow_request' as ApiKeyFastModePolicy,
   use_custom_key: false,
   custom_key: '',
   enable_ip_restriction: false,
@@ -1445,6 +1457,13 @@ const customKeyError = computed(() => {
 const statusOptions = computed(() => [
   { value: 'active', label: t('common.active') },
   { value: 'inactive', label: t('common.inactive') }
+])
+
+// 单 Key Fast 策略选项；Select 组件负责键盘与弹层交互。
+const fastModePolicyOptions = computed(() => [
+  { value: 'follow_request', label: t('keys.fastModePolicy.followRequest') },
+  { value: 'force_on', label: t('keys.fastModePolicy.forceOn') },
+  { value: 'force_off', label: t('keys.fastModePolicy.forceOff') }
 ])
 
 const shouldSubmitEditStatus = (key: ApiKey, status: 'active' | 'inactive') => {
@@ -1650,6 +1669,7 @@ const editKey = (key: ApiKey) => {
     name: key.name,
     group_id: key.group_id,
     status: key.status === 'quota_exhausted' || key.status === 'expired' ? 'inactive' : key.status,
+    fast_mode_policy: key.fast_mode_policy ?? 'follow_request',
     use_custom_key: false,
     custom_key: '',
     enable_ip_restriction: hasIPRestriction,
@@ -1898,6 +1918,7 @@ const submitKeyForm = async (
       const updates: UpdateApiKeyRequest = {
         name: formData.value.name,
         group_id: formData.value.group_id,
+        fast_mode_policy: formData.value.fast_mode_policy,
         ip_whitelist: ipWhitelist,
         ip_blacklist: ipBlacklist,
         quota: quota,
@@ -1918,6 +1939,7 @@ const submitKeyForm = async (
       const payload = {
         name: formData.value.name,
         group_id: formData.value.group_id,
+        fast_mode_policy: formData.value.fast_mode_policy,
         custom_key: customKey,
         ip_whitelist: ipWhitelist,
         ip_blacklist: ipBlacklist,
@@ -2003,6 +2025,7 @@ const closeModals = () => {
     name: '',
     group_id: null,
     status: 'active',
+    fast_mode_policy: 'follow_request',
     use_custom_key: false,
     custom_key: '',
     enable_ip_restriction: false,

--- a/frontend/src/views/user/__tests__/KeysView.spec.ts
+++ b/frontend/src/views/user/__tests__/KeysView.spec.ts
@@ -18,6 +18,7 @@ const {
   nextStep,
   getDataSharingNotice,
   confirmDataSharingNotice,
+  createKey,
 } = vi.hoisted(() => ({
   listKeys: vi.fn(),
   getPublicSettings: vi.fn(),
@@ -31,6 +32,7 @@ const {
   nextStep: vi.fn(),
   getDataSharingNotice: vi.fn(),
   confirmDataSharingNotice: vi.fn(),
+  createKey: vi.fn(),
 }))
 
 const messages: Record<string, string> = {
@@ -62,6 +64,7 @@ vi.mock('@/api', () => ({
   keysAPI: {
     list: listKeys,
     create: vi.fn(),
+    createWithPayload: createKey,
     update: vi.fn(),
     delete: vi.fn(),
     toggleStatus: vi.fn(),
@@ -128,6 +131,7 @@ const createApiKey = (): ApiKey => ({
   name: 'test-key',
   group_id: null,
   status: 'active',
+  fast_mode_policy: 'follow_request',
   ip_whitelist: [],
   ip_blacklist: [],
   last_used_at: null,
@@ -154,6 +158,11 @@ const createApiKey = (): ApiKey => ({
 
 const AppLayoutStub = {
   template: '<div><slot /></div>',
+}
+
+const BaseDialogStub = {
+  props: ['show'],
+  template: '<div v-if="show"><slot /><slot name="footer" /></div>',
 }
 
 const TablePageLayoutStub = {
@@ -232,7 +241,7 @@ const mountView = async () => {
         TablePageLayout: TablePageLayoutStub,
         DataTable: DataTableStub,
         Pagination: PaginationStub,
-        BaseDialog: true,
+        BaseDialog: BaseDialogStub,
         ConfirmDialog: true,
         EmptyState: true,
         Select: SelectStub,
@@ -282,6 +291,7 @@ describe('user KeysView column settings', () => {
     nextStep.mockReset()
     getDataSharingNotice.mockReset()
     confirmDataSharingNotice.mockReset()
+    createKey.mockReset()
 
     listKeys.mockResolvedValue({
       items: [createApiKey()],
@@ -295,6 +305,7 @@ describe('user KeysView column settings', () => {
     getAvailableGroups.mockResolvedValue([])
     getUserGroupRates.mockResolvedValue({})
     isCurrentStep.mockReturnValue(false)
+    createKey.mockResolvedValue(createApiKey())
   })
 
   it('uses the default API key columns with low-frequency columns hidden', async () => {
@@ -448,5 +459,42 @@ describe('user KeysView column settings', () => {
       },
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     )
+  })
+
+  it('submits the selected Fast mode policy when creating a key', async () => {
+    getAvailableGroups.mockResolvedValueOnce([{
+      id: 42,
+      name: 'OpenAI',
+      description: '',
+      display_brand: '',
+      rate_multiplier: 1,
+      peak_rate_enabled: false,
+      peak_start: '',
+      peak_end: '',
+      peak_rate_multiplier: 1,
+      platform: 'openai',
+      data_sharing_enabled: false,
+    }])
+    const wrapper = await mountView()
+
+    await getButtonByText(wrapper, 'Create API Key').trigger('click')
+    await nextTick()
+    await wrapper.get('[data-tour="key-form-name"]').setValue('fast-key')
+
+    const selects = wrapper.findAllComponents({ name: 'Select' })
+    const groupSelect = selects.find((select) => select.attributes('data-tour') === 'key-form-group')
+    const fastSelect = selects.find((select) => select.attributes('data-test') === 'fast-mode-policy-select')
+    expect(groupSelect).toBeDefined()
+    expect(fastSelect).toBeDefined()
+    await groupSelect!.vm.$emit('update:modelValue', 42)
+    await fastSelect!.vm.$emit('update:modelValue', 'force_on')
+    await wrapper.get('form#key-form').trigger('submit')
+    await flushPromises()
+
+    expect(createKey).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'fast-key',
+      group_id: 42,
+      fast_mode_policy: 'force_on',
+    }))
   })
 })


### PR DESCRIPTION
## Summary

- add per-API-key `follow_request`, `force_on`, and `force_off` Fast mode policies with migration 199, CRUD validation, auth caching, and UI controls
- apply the policy only when the active group model supports service tiers, while preserving higher-priority system filter/block/force rules
- support OpenAI HTTP and Realtime paths plus Claude native, passthrough, and compatibility paths; OpenAI force-off deletes `service_tier` instead of writing `default` or `flex`
- capture Claude `usage.speed` for Fast billing and usage logs

## Validation

- `make generate`
- `go test ./...`
- `go test -tags unit ./internal/service ./internal/repository ./internal/server/middleware`
- `vue-tsc -b`
- `eslint .`
- `vitest run --silent --reporter=basic` (171 files, 1086 tests)
- `vite build`